### PR TITLE
Automate docs build on main branch push

### DIFF
--- a/.github/workflows/build_uan_docs.yaml
+++ b/.github/workflows/build_uan_docs.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_and_publish_docs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -43,15 +43,21 @@ jobs:
           rm -rf docs-uan
 
       - name: Check out docs-uan repository
-        uses: actions/checkout@v2
-        with:
-          path: docs-uan
+        uses: actions/checkout@v3
 
-      - name: Run generator
+      - name: Generate HTML docs
         env:
           GIT_AUTHOR_NAME: "Cray-HPE Github Bot"
           GIT_AUTHOR_EMAIL: noreply@hpe.com
           GIT_COMMITTER_NAME: "Cray-HPE Github Bot"
           GIT_COMMITTER_EMAIL: noreply@hpe.com
-        run: build-hugo-docs.py
-        working-directory: docs-uan
+        run: ./build-hugo-docs.py
+
+      - name: Push generated HTML
+        if: success() && github.ref == 'refs/heads/master'
+        env:
+          GIT_AUTHOR_NAME: "Cray-HPE Github Bot"
+          GIT_AUTHOR_EMAIL: noreply@hpe.com
+          GIT_COMMITTER_NAME: "Cray-HPE Github Bot"
+          GIT_COMMITTER_EMAIL: noreply@hpe.com
+        run: ./build-hugo-docs.py --no-clone --no-build --publish


### PR DESCRIPTION
#### Summary and Scope

- Fixes casmuser-2930

This PR enables HTML docs to be built on a push to the main branch. 

#### Risks and Mitigations
 
Low risk.
