### PR TITLE
deleted empty container topics. Use topicheads in the ditamaps instead

### DIFF
--- a/docs/portal/developer-portal/About_UAN_Administration.md
+++ b/docs/portal/developer-portal/About_UAN_Administration.md
@@ -1,1 +1,0 @@
-# About UAN Administration

--- a/docs/portal/developer-portal/Administrative_Tasks.md
+++ b/docs/portal/developer-portal/Administrative_Tasks.md
@@ -1,1 +1,0 @@
-# Administrative Tasks

--- a/docs/portal/developer-portal/Advanced_Administrative_Tasks.md
+++ b/docs/portal/developer-portal/Advanced_Administrative_Tasks.md
@@ -1,1 +1,0 @@
-# Advanced Administrative Tasks

--- a/docs/portal/developer-portal/Known_Issues.md
+++ b/docs/portal/developer-portal/Known_Issues.md
@@ -1,1 +1,0 @@
-# Known Issues

--- a/docs/portal/developer-portal/Manage_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/Manage_UAN_Boot_Images.md
@@ -1,1 +1,0 @@
-# Manage UAN Boot Images

--- a/docs/portal/developer-portal/Reference.md
+++ b/docs/portal/developer-portal/Reference.md
@@ -1,1 +1,0 @@
-# Reference

--- a/docs/portal/developer-portal/Troubleshooting.md
+++ b/docs/portal/developer-portal/Troubleshooting.md
@@ -1,1 +1,0 @@
-# Troubleshooting

--- a/docs/portal/developer-portal/installation_prereqs/Hardware_and_Software_Prerequisites.md
+++ b/docs/portal/developer-portal/installation_prereqs/Hardware_and_Software_Prerequisites.md
@@ -1,1 +1,0 @@
-# Hardware and Software Prerequisites

--- a/docs/portal/developer-portal/uan_admin_guide.ditamap
+++ b/docs/portal/developer-portal/uan_admin_guide.ditamap
@@ -7,35 +7,41 @@
         <data name="pubsnumber" value="S-8033"></data>
 		<data name="edition" value="UAN Software Release @product_version@"></data>
     </topicmeta>
-    <topicref href="About_UAN_Administration.md" format="markdown">
+    <topichead>
+	    <topicmeta><navtitle>About UAN Administration</navtitle></topicmeta>
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>
-    </topicref>
-    <topicref href="Manage_UAN_Boot_Images.md" format="markdown">
+    </topichead>
+    <topichead>
+	    <topicmeta><navtitle>Manage UAN Boot Images</navtitle></topicmeta>
         <topicref href="operations/Create_UAN_Boot_Images.md" format="markdown"/>
         <topicref href="operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md" format="markdown"
         />
-    </topicref>
-    <topicref href="Administrative_Tasks.md" format="markdown">
+</topichead>
+    <topichead>	
+	    <topicmeta><navtitle>Administrative Tasks</navtitle></topicmeta>
         <topicref href="operations/Configure_Interfaces_on_UANs.md" format="markdown"/>
         <topicref href="operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md"
             format="markdown"/>
         <topicref href="operations/Mount_a_New_File_System_on_an_UAN.md" format="markdown"/>
         <topicref href="operations/Boot_UANs.md" format="markdown"/>
-    </topicref>
-    <topicref href="Advanced_Administrative_Tasks.md" format="markdown">
+    </topichead>
+    <topichead> 
+	<topicmeta><navtitle>Advanced Administrative Tasks</navtitle></topicmeta>
         <topicref href="advanced/Customizing_UAN_Images_Manually.md" format="markdown"/>
         <topicref href="advanced/Repurposing_Compute_as_UAN.md" format="markdown"/>
         <topicref href="advanced/Enabling_CAN_CHN.md" format="markdown"/>
         <topicref href="advanced/SLES_Image.md" format="markdown"/>
-    </topicref>
-    <topicref href="Troubleshooting.md" format="markdown">
+    </topichead>
+    <topichead>
+	<topicmeta><navtitle>Troubleshooting</navtitle></topicmeta>
         <topicref href="troubleshooting/Troubleshoot_UAN_Boot_Issues.md" format="markdown"/>
         <topicref href="troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md"
             format="markdown"/>
         <topicref href="troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md"
             format="markdown"/>
-    </topicref>
-    <topicref href="Reference.md" format="markdown">
+    </topichead>
+    <topichead>
+	<topicmeta><navtitle>Reference</navtitle></topicmeta>
         <topicref href="operations/UAN_Ansible_Roles.md" format="markdown"/>
-    </topicref>
+    </topichead>
 </map>

--- a/docs/portal/developer-portal/uan_install_guide.ditamap
+++ b/docs/portal/developer-portal/uan_install_guide.ditamap
@@ -9,7 +9,8 @@
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>
-    <topicref href="installation_prereqs/Hardware_and_Software_Prerequisites.md" format="markdown">
+    <topichead>
+	    <topicmeta><navtitle>Hardware and Software Prerequisites</navtitle></topicmeta>    
         <topicref href="installation_prereqs/Prepare_for_UAN_Product_Installation.md"
             format="markdown"/>
         <topicref href="installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md"
@@ -17,7 +18,7 @@
         <topicref href="installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md" format="markdown"/>
         <topicref href="installation_prereqs/Configure_the_BIOS_of_a_Gigabyte_UAN.md"
             format="markdown"/>
-    </topicref>
+    </topichead>
     <topicref href="advanced/Enabling_CAN_CHN.md" format="markdown"/>
     <topicref href="install/Install_the_UAN_Product_Stream.md" format="markdown"/>
     <topicref href="upgrade/Merge_UAN_Configuration_Data.md" format="markdown"/>


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3151


##### Issue Type
<!--- Delete un-needed bullets -->

- Docs Pull Request

<!--- words; describe what this change is and what it is for. -->

#### Prerequisites

I tested this change by running the ./build.sh script on the updated ditamaps for the UAN guides. No errors reported.
 

