### PR TITLE
casmuser-2677: Update Configure Interfaces on UANs for NMN bonding

### DIFF
--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -1,15 +1,23 @@
 
 # Configure Interfaces on UANs
 
-Perform this procedure to set network interfaces on UANs by editing a configuration file.
+Perform this procedure to configure network interfaces on UANs by editing a configuration file.
 
 Interface configuration is performed by the `uan_interfaces` Ansible role. For details on the variables referred to in this procedure, see [UAN Ansible Roles](UAN_Ansible_Roles.md).
 
-In the command examples in this procedure, `PRODUCT_VERSION` refers to the current installed version of the UAN product. Replace `PRODUCT_VERSION` with the UAN version number string when executing the commands.  
+In the command examples of this procedure, `PRODUCT_VERSION` refers to the current installed version of the UAN product. Replace `PRODUCT_VERSION` with the UAN version number string when executing the commands.
 
-User access may be configured to use either a direct connection to the UANs from the sites user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) or Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
+## User Access Networking
 
-By default, a direct connection to the sites user network is assumed and the Admin must define the interface and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. When CAN or CHN are selected, the interfaces and default route are setup automatically.
+User access may be configured to use either a direct connection to the UANs from the sites user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) and Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
+
+By default, a direct connection to the sites user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.  When CAN is selected as the system default route in SLS, the CAN interfaces are defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\) and the default route is set to the bonded CAN interface `can0`. When CHN is selected as the system default route in SLS, the CHN IP is added to `hsn0` and the default route is set to the CHN. The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
+
+## Node Management Networking
+
+By default, the Node Management Network \(NMN\) is connected to a single `nmn0` interface.  If desired, and the system networking is configured to support it, the Node Management Network may be configured as a bonded interface, `nmnb0`. To configure the NMN as a bonded pair, set `uan_nmn_bond` to true and list the pair of NMN interfaces in `uan_nmn_bond_slaves` as described in [UAN Ansible Roles](UAN_Ansible_Roles.md).
+
+## Procedure
 
 Network configuration settings are defined in the `uan-config-management` VCS repo under the `group_vars/ROLE_SUBROLE/` or `host_vars/XNAME/` directories, where `ROLE_SUBROLE` must be replaced by the role and subrole assigned for the node in HSM, and `XNAME` with the xname of the node. Values under `group_vars/ROLE_SUBROLE/` apply to all nodes with the given role and subrole.  Values under the `host_vars/XNAME/` apply to the specific node with the xname and will override any values set in `group_vars/ROLE_SUBROLE/`.  A yaml file is used by the Configuration Framwork Service \(CFS\).  The examples in this procedure use `customer_net.yml`, but any filename may be used.  Admins must create this yaml file and use the variables described in this procedure.
 
@@ -46,6 +54,14 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     # use the Shasta CAN or CHN network for user access.
     # By default, uan_can_setup is set to 'no'.
     uan_can_setup: yes
+
+    ## uan_can_bond_slaves
+    # This variable only applies when the system default route is CAN.
+    # These are the default CAN bond slaves.  They may need to be
+    # changed based on the actual system hardware configuration.
+    uan_can_bond_slaves:
+      - "ens10f1"
+      - "ens1f1"
     ```
 
     To allow a custom default route when CAN or CHN is selected:
@@ -54,6 +70,23 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     ## uan_customer_default_route
     # Allow a custom default route when CAN or CHN is selected.
     uan_customer_default_route: no
+    ```
+
+    To enable bonded NMN interfaces:
+
+    ```bash
+    ## uan_nmn_bond
+    # Set uan_nmn_bond to 'yes' if the site will
+    # implement a bonded NMN connection.
+    # By default, uan_nmn_bond is set to 'no'.
+    uan_nmn_bond: yes
+
+    ## uan_nmn_bond_slaves
+    # These are the default NMN bond slaves.  They may need to be
+    # changed based on the actual system hardware configuration.
+    uan_nmn_bond_slaves:
+      - "ens10f0"
+      - "ens1f0"
     ```
 
     To define interfaces:


### PR DESCRIPTION
#### Summary and Scope
This PR updates the documentation for supporting bonded NMN interfaces and also updates the way bonded interfaces for CAN are defined.

Fixes [CASMUSER-2677](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2677)
Fixes [CASMUSER-2900](https://jira-pro.its.hpecorp.net:8443/browse/CASMUSER-2900)

Merge after https://github.com/Cray-HPE/uan/pull/62 which is the code change PR.