### PR TITLE
Add setting UAN password steps to docs

### DIFF
--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -40,10 +40,61 @@ This section describes any UAN details that an administrator may need to be awar
 
 The following subsections describe the majority of the UAN content installed and configured on the system by IUF. The new version of UAN \(2.6.XX\) and its artifacts will be displayed in the CSM product catalog alongside any previously released version of UAN and its artifacts.
 
+
 ### Configuration
 
 UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number \(2.6.XX\) to distinguish it from any previously released UAN configuration content. This content is described in detail in the [About UAN Configuration](../operations/About_UAN_Configuration.md) section.
 
+For application nodes based on COS, the COS compute image is used as the base application node image and two COS CFS layers are required. The `cos-application.yml` Ansible playbook ensures that the COS content is applied as part of the image customization and node personalization processes. A second Ansible playbook, `cos-application-after.yml`, runs at the end to ensure that the application node initrd is rebuilt.
+
+Input files for `sat bootprep` are provided in the `hpc-csm-software-recipe` VCS repository and include COS components in the CFS configuration, node image, and BOS session template definitions. The `compute-and-uan-bootprep.yaml` input file is used for compute and application nodes.
+
+### Procedure to Set Root Password For UAN/Application Nodes
+
+The following instructions describe how to set the root password for UAN/Application nodes.
+
+1.  Obtain the HashiCorp Vault root token.
+
+    ```bash
+    ncn-m001# kubectl get secrets -n vault cray-vault-unseal-keys \
+    -o jsonpath='{.data.vault-root}' | base64 -d; echo
+    ```
+
+1.  Log into the HashiCorp Vault pod.
+
+    ```bash
+    ncn-m001# kubectl exec -itn vault cray-vault-0 -c vault -- sh
+    ```
+
+1.  Once attached to the pod's shell, log into vault and read the `secret/cos` key by executing the following commands. If the secret is empty, "No value found at secret/cos" will be displayed.
+
+    ```bash
+    pod# export VAULT_ADDR=http://cray-vault:8200
+    pod# vault login
+    pod# vault read secret/uan
+    ```
+
+1.  If no value is found for this key, complete the following steps in another shell on the NCN management node.
+
+    a.  Generate the password HASH for the root user. Replace 'PASSWORD' with a chosen root password.
+
+        ```bash
+        ncn-m001# openssl passwd -6 -salt $(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c4) PASSWORD
+        ```
+
+    b.  Take the HASH value returned from the previous command and enter the following in the vault pod's shell. Instead of HASH, use the value returned from the previous step.  You must escape the HASH value with the single quote to preserve any special characters that are part of the HASH value. If you previously have exited the pod, repeat steps 1-3 above; there is no need to perform the vault read since the content is empty.
+
+        ```bash
+        pod# vault write secret/uan root_password='HASH'
+        ```
+
+    c.  Verify the new hash value is stored.
+
+        ```bash
+        pod# vault read secret/uan
+        ...
+        pod# exit
+        ```
 ### UAN Stock Kernel Image
 
 UAN provides a stock kernel Application Node image which may be used on Application nodes that do not require any COS compatibility as UAN does. This image is not based on the COS image which the default UAN image is and is uploaded to IMS as part of the installation process. The stock kernel Application Node image is based on SLES 15 SP4.


### PR DESCRIPTION
#### Summary and Scope
This PR adds the procedure for setting the UAN root password to the docs.  It also adds some notes about COS layers that are required for UAN CFS configuration.