### PR TITLE
casmuser-2677: Add Ansible roles changes for NMN bonding

### DIFF
--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -11,11 +11,15 @@ In the command examples of this procedure, `PRODUCT_VERSION` refers to the curre
 
 User access may be configured to use either a direct connection to the UANs from the sites user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) and Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
 
-By default, a direct connection to the sites user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.  When CAN is selected as the system default route in SLS, the CAN interfaces are defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\) and the default route is set to the bonded CAN interface `can0`. When CHN is selected as the system default route in SLS, the CHN IP is added to `hsn0` and the default route is set to the CHN. The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
+By default, a direct connection to the sites user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.
+
+* When CAN is set elected as the system default route in SLS, the bonded CAN interfaces are defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\) and the default route is set to the bonded CAN interface `can0`.
+
+* When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` and the default route is set to the CHN. The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
 
 ## Node Management Networking
 
-By default, the Node Management Network \(NMN\) is connected to a single `nmn0` interface.  If desired, and the system networking is configured to support it, the Node Management Network may be configured as a bonded interface, `nmnb0`. To configure the NMN as a bonded pair, set `uan_nmn_bond` to true and list the pair of NMN interfaces in `uan_nmn_bond_slaves` as described in [UAN Ansible Roles](UAN_Ansible_Roles.md).
+By default, the Node Management Network \(NMN\) is connected to a single `nmn0` interface.  If desired, and the system networking is configured to support it, the Node Management Network may be configured as a bonded interface, `nmnb0`. To configure the NMN as a bonded pair, set `uan_nmn_bond` to true and set the interfaces to be used in the bond in `uan_nmn_bond_slaves` as described in [UAN Ansible Roles](UAN_Ansible_Roles.md).
 
 ## Procedure
 

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -11,9 +11,9 @@ In the command examples of this procedure, `PRODUCT_VERSION` refers to the curre
 
 User access may be configured to use either a direct connection to the UANs from the sites user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) and Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
 
-By default, a direct connection to the sites user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.
+By default, a direct connection to the site's user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.
 
-* When CAN is set elected as the system default route in SLS, the bonded CAN interfaces are defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\) and the default route is set to the bonded CAN interface `can0`.
+* When CAN is set as the system default route in SLS, the bonded CAN interfaces are defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\) and the default route is set to the bonded CAN interface `can0`.
 
 * When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` and the default route is set to the CHN. The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
 

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -222,6 +222,44 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+`uan_nmn_bond`
+
+`uan_nmn_bond` is a boolean variable controlling the configuration of the Node Management Network (NMN).
+When true, the NMN network connection will be configured as a bonded pair of interfaces defined by the members of the
+`uan_nmn_bond_slaves` variable. The bonded NMN interface is named `nmnb0`. When false, the NMN network connection
+will be configured as a single interface named `nmn0`.
+
+The default value of `uan_nmn_bond` is `no`.
+
+```yaml
+uan_nmn_bond: no
+```
+
+`uan_nmn_bond_slaves`
+
+`uan_nmn_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_nmn_bond` is true.
+
+The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f0`
+which is the first port of the NIC in slot 10.  
+
+**NOTE:** `ens10f0` is typically the first port of the OCP 25Gb card that
+the node PXE boots.
+
+**IMPORTANT!** The first interface in the list must be the `nmn0` interface which is configured during the
+initial image boot, typically `ens10f0`.  This is required because the MAC address of the `nmn0` interface
+is the MAC associated with the IP address of the UAN.  The bonded `nmnb0` interface and the bond slaves
+will assume this MAC and the IP address of `nmn0` to preserve connectivity.
+
+The second interface is typically the first port of a different 25Gb NIC for resiliency.
+
+The default values of `uan_nmn_bond_slaves are shown here.  They may need to be changed to match the actual
+node cabling and NIC configuration.
+```yaml
+uan_nmn_bond_slaves:
+  - "ens10f0"
+  - "ens1f0"
+```
+
 `uan_can_setup`
 
 Boolean variable controlling the configuration of user
@@ -236,6 +274,27 @@ The default value of `uan_can_setup` is `no`.
 
 ```yaml
 uan_can_setup: no
+```
+
+`uan_can_bond_slaves`
+
+`uan_can_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_can_setup` is true
+and the Customer Access Network (CAN) is configured on the system.
+
+The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f1`
+which is the second port of the NIC in slot 10.  
+
+**NOTE:** `ens10f1` is typically the second port of the OCP 25Gb card and is used as one of the bond
+slaves in the CAN `bond0` interface.
+
+The second interface is typically the second port of a different 25Gb NIC for resiliency.
+
+The default values of `uan_can_bond_slaves are shown here.  They may need to be changed to match the actual
+node cabling and NIC configuration.
+```yaml
+uan_can_bond_slaves:
+  - "ens10f1"
+  - "ens1f1"
 ```
 
 `uan_customer_default_route`

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -252,7 +252,7 @@ will assume this MAC and the IP address of `nmn0` to preserve connectivity.
 
 The second interface is typically the first port of a different 25Gb NIC for resiliency.
 
-The default values of `uan_nmn_bond_slaves are shown here.  They may need to be changed to match the actual
+The default values of `uan_nmn_bond_slaves` are shown here.  They may need to be changed to match the actual
 node cabling and NIC configuration.
 ```yaml
 uan_nmn_bond_slaves:


### PR DESCRIPTION
#### Summary and Scope
This PR updates the UAN_Ansible_Roles.md file to include the new variables supporting bonded NMN and the new way CAN slaves are defined.  It also clarifies some of the wording around CAN and bonded NMN in Configure_Interfaces_on_UANs.md.