### PR TITLE
Casmuser 3055

### DIFF
--- a/docs/portal/developer-portal/build.sh
+++ b/docs/portal/developer-portal/build.sh
@@ -59,10 +59,13 @@ mkdir -m777 -p build/install
 mkdir -m777 -p build/admin
 mkdir -m777 -p build/Markdown
 
+# call the script that flattens the dir structure used to build the HPESC bundle
+./flatten.sh
+
 echo "Building UAN Install Guide";
 
 # This line builds the HPESC HTML bundle for the install guide
-dita -i uan_install_guide.ditamap -o build/install -f HPEscHtml5 && cp install_publication.json build/install/publication.json && cd build/install/ && zip -r crs8032_3en_us.zip ./
+dita -i tmp/uan_install_guide.ditamap -o build/install -f HPEscHtml5 && cp install_publication.json build/install/publication.json && cd build/install/ && zip -r crs8032_3en_us.zip ./
 cd $THIS_DIR
 # This builds the PDF using DITA-OT's default PDF transform
 dita -i uan_install_guide.ditamap -o build/PDF/install -f pdf
@@ -71,12 +74,15 @@ dita -i uan_install_guide.ditamap --root-chunk-override=to-content -o build/Mark
 
 # Repeat the process for the Admin Guide
 echo "Building UAN Admin Guide"
-dita -i uan_admin_guide.ditamap -o build/admin -f HPEscHtml5 && cp admin_publication.json build/admin/publication.json && cd build/admin/ && zip -r crs8033_3en_us.zip ./
+dita -i tmp/uan_admin_guide.ditamap -o build/admin -f HPEscHtml5 && cp admin_publication.json build/admin/publication.json && cd build/admin/ && zip -r crs8033_3en_us.zip ./
 cd $THIS_DIR
 # This builds the PDF using DITA-OT's default PDF transform
 dita -i uan_admin_guide.ditamap -o build/PDF/admin -f pdf; 
 # This builds the single file Markdown version of the guide. This leverages DITA's "chunking"
 dita -i uan_admin_guide.ditamap --root-chunk-override=to-content -o build/Markdown -f markdown_github
+
+# delete the tmp dir created by the flatten script. The bundle is still in the build subdir
+rm -rf tmp/
 
 # DITA-OT spits out the individual Markdown files (which we don't want) in addition to the unified Md files (that we do want). These lines get rid of the extra files 
 mv build/Markdown/uan_*_guide.md build/

--- a/docs/portal/developer-portal/flatten.sh
+++ b/docs/portal/developer-portal/flatten.sh
@@ -1,7 +1,10 @@
 # create tmp subdir
 mkdir tmp
+mkdir tmp/images
 # copy all markdown files to the tmp subdir
 cp ./*/*.md tmp/
+# copy all images to the tmp subdir
+cp ./*/*/*.png tmp/images/
 # copy both ditamaps to the tmp subdir 
 cp ./*.ditamap tmp/
 # convert links in the UAN IG ditamap
@@ -9,13 +12,14 @@ sed -i 's/installation_prereqs\///' tmp/uan_install_guide.ditamap
 sed -i 's/install\///' tmp/uan_install_guide.ditamap
 sed -i 's/operations\///' tmp/uan_install_guide.ditamap
 sed -i 's/advanced\///' tmp/uan_install_guide.ditamap
+sed -i 's/upgrade\///' tmp/uan_install_guide.ditamap
 
 # convert links in the UAN AG ditamap
 sed -i 's/advanced\///' tmp/uan_admin_guide.ditamap
 sed -i 's/operations\///' tmp/uan_admin_guide.ditamap
 sed -i 's/troubleshooting\///' tmp/uan_admin_guide.ditamap
+sed -i 's/upgrade\///' tmp/uan_admin_guide.ditamap
 
 # convert all links in all Markdown files. 
-# for every file in "ls tmp/*.md", for every string in "installation_prereqs, install, operations, advanced, troubleshooting", replace that string with nothing
-declare -a prefixes=("\.\.\/installation_prereqs" "\.\.\/install" "\.\.\/operations" "\.\.\/advanced" "\.\.\/troubleshooting")
+declare -a prefixes=("\.\.\/installation_prereqs" "\.\.\/install" "\.\.\/operations" "\.\.\/advanced" "\.\.\/troubleshooting" "\.\.\/upgrade" "\.\.\/images")
 for file in $(ls tmp/*.md);do for prefix in ${prefixes[@]}; do sed -i "s/$prefix\///g" $file;done;done

--- a/docs/portal/developer-portal/flatten.sh
+++ b/docs/portal/developer-portal/flatten.sh
@@ -1,0 +1,21 @@
+# create tmp subdir
+mkdir tmp
+# copy all markdown files to the tmp subdir
+cp ./*/*.md tmp/
+# copy both ditamaps to the tmp subdir 
+cp ./*.ditamap tmp/
+# convert links in the UAN IG ditamap
+sed -i 's/installation_prereqs\///' tmp/uan_install_guide.ditamap
+sed -i 's/install\///' tmp/uan_install_guide.ditamap
+sed -i 's/operations\///' tmp/uan_install_guide.ditamap
+sed -i 's/advanced\///' tmp/uan_install_guide.ditamap
+
+# convert links in the UAN AG ditamap
+sed -i 's/advanced\///' tmp/uan_admin_guide.ditamap
+sed -i 's/operations\///' tmp/uan_admin_guide.ditamap
+sed -i 's/troubleshooting\///' tmp/uan_admin_guide.ditamap
+
+# convert all links in all Markdown files. 
+# for every file in "ls tmp/*.md", for every string in "installation_prereqs, install, operations, advanced, troubleshooting", replace that string with nothing
+declare -a prefixes=("\.\.\/installation_prereqs" "\.\.\/install" "\.\.\/operations" "\.\.\/advanced" "\.\.\/troubleshooting")
+for file in $(ls tmp/*.md);do for prefix in ${prefixes[@]}; do sed -i "s/$prefix\///g" $file;done;done


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3055

##### Issue Type

- Docs portal Bugfix Pull Request

This flattens the directory structure (and updates links in the Markdown files) of the source files used by DITA-OT to build the HTML5 and JSON bundle that gets uploaded to HPESC. Only the HPESC bundle build path is affected by this.

This is a docs tooling-only change.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (Ubuntu on WSL2) by performing the entire build and publishing process: running `release.sh`, running `build.sh` within the content copy in the `dist` subdir, and finally running the script that uploads the content ITG. No build errors from DITA-OT. Manually verified that internal cross-references from one source Markdown file to another within the portal-generated PDF now work.


#### Risks and Mitigations
 
Very low risk to the Hugo build process or to the process that builds the PDF/HTML tarball. 

**NOTE** From now on we must avoid having two Markdown files with the exact same file name.

#### Follow-up Changes Needed

We need a follow-up PR that replaces cross-references of this type: `[Link Text](MARKDOWN_FILE_NAME.md#SUBSECTION)`

with links of this type: `[Link Text](MARKDOWN_FILE_NAME.md)` if we want those cross-references to work in the PDF generated by the portal from the HTML.

