### PR TITLE
Casmuser 3181 2.5: Bonded UAN for UAN-2.5.9

### DIFF
--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -1,0 +1,177 @@
+[
+  {
+    "title": "UAN Documentation",
+    "dir": "/",
+    "weight": 10
+  },
+  {
+    "title": "Cray Ex User Access Nodes Installation And Administration Guide",
+    "dir": "/",
+    "weight": 15
+  },
+  {
+    "title": "Installation Prereqs",
+    "dir": "installation_prereqs",
+    "weight": 20,
+    "toc": [
+        "Prepare_for_UAN_Product_Installation.md",
+        "Configure_the_BMC_for_UANs_with_iLO.md",
+        "Configure_the_BIOS_of_an_HPE_UAN.md",
+        "Configure_the_BIOS_of_a_Gigabyte_UAN.md"
+    ]
+  },
+  {
+    "title": "Prepare For UAN Product Installation",
+    "weight": 21
+  },
+  {
+    "title": "Configure The BMC For UANs With iLO",
+    "weight": 22
+  },
+  {
+    "title": "Configure The BIOS Of An HPE UAN",
+    "weight": 23
+  },
+  {
+    "title": "Configure The BIOS Of A Gigabyte UAN",
+    "weight": 24
+  },
+  { 
+    "title": "Install",
+    "dir": "install",
+    "weight": 30,
+    "toc": [
+        "Install_the_UAN_Product_Stream.md"
+    ]
+  },
+  {
+    "title": "Operations",
+    "dir": "operations",
+    "weight": 40,
+    "toc": [
+        "About_UAN_Configuration.md",
+        "Build_a_New_UAN_Image_Using_the_COS_Recipe.md",
+        "Create_UAN_Boot_Images.md",
+        "Mount_a_New_File_System_on_an_UAN.md",
+        "Configure_Interfaces_on_UANs.md",
+        "Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md",
+        "UAN_Ansible_Roles.md",
+        "Boot_UANs.md"
+    ]
+  },
+  {
+    "title": "About UAN Configuration",
+    "weight": 41
+  },
+  {
+    "title": "Build A New UAN Image Using A COS Recipe",
+    "weight": 42
+  },
+  {
+    "title": "Create UAN Boot Images",
+    "weight": 43
+  },
+  {
+    "title": "Mount A New File System On A UAN",
+    "weight": 44
+  },
+  {
+    "title": "Configure Interfaces On UANs",
+    "weight": 45
+  },
+  {
+    "title": "Configure Pluggable Authentication Modules (pam) On UANs",
+    "weight": 46
+  },
+  {
+    "title": "UAN Ansible Roles",
+    "weight": 47
+  },
+  {
+    "title": "Boot UANs",
+    "weight": 48
+  },
+  {
+    "title": "Advanced",
+    "dir": "advanced",
+    "weight": 50,
+    "toc": [
+        "Customizing_UAN_Images_Manually.md",
+        "Enabling_CAN_CHN.md",
+        "Repurposing_Compute_as_UAN.md",
+        "SLES_Image.md"
+    ]
+  },
+  {
+    "title": "Customizing UAN Images Manually",
+    "weight": 51
+  },
+  {
+    "title": "Enabling The Customer Access Network (CAN) Or The Customer High Speed Network (chn)",
+    "weight": 52
+  },
+  {
+    "title": "Repurposing A Compute Node As A UAN",
+    "weight": 53
+  },
+  {
+    "title": "Booting An Application Node With A Sles Image (TechNICal Preview)",
+    "weight": 54
+  },
+  {
+    "title": "Configuring A UAN For K3s (techNICal Preview)",
+    "weight": 55
+  },
+  {
+    "title": "Upgrade",
+    "dir": "upgrade",
+    "weight": 60,
+    "toc": [
+      "Notable_Changes.md",
+      "Upgrade_UAN_Software_Product.md",
+      "Merge_UAN_Configuration_Data.md"
+    ]
+  },
+  {
+    "title": "Notable Changes",
+    "weight": 61
+  },
+  {
+    "title": "Upgrade UAN Software Product",
+    "weight": 62
+  },
+  {
+    "title": "Merge UAN Configuration Data",
+    "weight": 63
+  },
+  {
+    "title": "Troubleshooting",
+    "dir": "troubleshooting",
+    "weight": 70,
+    "toc": [
+        "Troubleshoot_UAN_Boot_Issues.md",
+        "Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md",
+        "Troubleshoot_UAN_Disk_Configuration_Issues.md"
+    ]
+  },
+  {
+    "title": "Troubleshoot UAN Boot Issues",
+    "weight": 71
+  },
+  {
+    "title": "Troubleshoot UAN CFS And Network Configuration Issues",
+    "weight": 72
+  },
+  {
+    "title": "Troubleshoot UAN Disk Configuration Issues",
+    "weight": 73
+  },
+  {
+    "title": "Test Plan",
+    "dir": "test-plan",
+    "weight": 80,
+    "toc": [
+        "test-plan.md"
+    ]
+  }
+]

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -7,9 +7,23 @@ Interface configuration is performed by the `uan_interfaces` Ansible role. For d
 
 In the command examples in this procedure, `PRODUCT_VERSION` refers to the current installed version of the UAN product. Replace `PRODUCT_VERSION` with the UAN version number string when executing the commands.  
 
-User access may be configured to use either a direct connection to the UANs from the sites user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) or Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
+## Node Management Networking
 
-By default, a direct connection to the sites user network is assumed and the Admin must define the interface and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. When CAN or CHN are selected, the interfaces and default route are setup automatically.
+By default, the Node Management Network \(NMN\) is connected to a single `nmn0` interface.  If desired, and the system networking is configured to support it, the Node Management Network may be configured as a bonded interface, `nmnb0`. To configure the NMN as a bonded pair, set `uan_nmn_bond` to true and set the interfaces to be used in the bond in `uan_nmn_bond_slaves` as described in [UAN Ansible Roles](UAN_Ansible_Roles.md).
+
+## User Access Networking
+
+User access may be configured to use either a direct connection to the UANs from the site's user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) and Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
+
+By default, a direct connection to the site's user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.
+
+* When CAN is set as the system default route in SLS and `uan_nmn_bond` is false, the bonded CAN interfaces are determined automatically.  If `uan_nmn_bond` is true, the bonded CAN interfaces must be defined by `uan_can_bond_slaves` \(see [UAN Ansible Roles](UAN_Ansible_Roles.md)\). The default route is set to the bonded CAN interface `can0`.
+
+* When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` and the default route is set to the CHN.
+
+* The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
+
+## Procedure
 
 Network configuration settings are defined in the `uan-config-management` VCS repo under the `group_vars/ROLE_SUBROLE/` or `host_vars/XNAME/` directories, where `ROLE_SUBROLE` must be replaced by the role and subrole assigned for the node in HSM, and `XNAME` with the xname of the node. Values under `group_vars/ROLE_SUBROLE/` apply to all nodes with the given role and subrole.  Values under the `host_vars/XNAME/` apply to the specific node with the xname and will override any values set in `group_vars/ROLE_SUBROLE/`.  A yaml file is used by the Configuration Framwork Service \(CFS\).  The examples in this procedure use `customer_net.yml`, but any filename may be used.  Admins must create this yaml file and use the variables described in this procedure.
 
@@ -38,6 +52,23 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
 
 5. Edit the yaml file, \(`customer_net.yml`, for example\), in either the `group_vars/ROLE_SUBROLE/` or `host_vars/XNAME` directory and configure the values as needed.
 
+    To enable bonded NMN interfaces:
+
+    ```bash
+    ## uan_nmn_bond
+    # Set uan_nmn_bond to 'yes' if the site will
+    # implement a bonded NMN connection.
+    # By default, uan_nmn_bond is set to 'no'.
+    uan_nmn_bond: yes
+
+    ## uan_nmn_bond_slaves
+    # These are the default NMN bond slaves.  They may need to be
+    # changed based on the actual system hardware configuration.
+    uan_nmn_bond_slaves:
+      - "ens10f0"
+      - "ens1f0"
+    ```
+
     To set up CAN or CHN:
 
     ```bash
@@ -46,6 +77,15 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     # use the Shasta CAN or CHN network for user access.
     # By default, uan_can_setup is set to 'no'.
     uan_can_setup: yes
+
+    ## uan_can_bond_slaves
+    # This variable only applies when the system default route is CAN
+    # and `uan_nmn_bond` is true.
+    # These are the default CAN bond slaves.  They may need to be
+    # changed based on the actual system hardware configuration.
+    uan_can_bond_slaves:
+      - "ens10f1"
+      - "ens1f1"
     ```
 
     To allow a custom default route when CAN or CHN is selected:

--- a/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
+++ b/docs/portal/developer-portal/operations/UAN_Ansible_Roles.md
@@ -164,7 +164,39 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-### `uan_can_setup`
+
+`uan_nmn_bond`
+
+`uan_nmn_bond` is a boolean variable controlling the configuration of the Node Management Network (NMN). When true, the NMN network connection will be configured as a bonded pair of interfaces defined by the members of the `uan_nmn_bond_slaves` variable. The bonded NMN interface is named `nmnb0`. When false, the NMN network connection will be configured as a single interface named `nmn0`.
+
+The default value of `uan_nmn_bond` is `no`.
+
+```yaml
+uan_nmn_bond: no
+```
+
+`uan_nmn_bond_slaves`
+
+`uan_nmn_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_nmn_bond` is true.
+
+The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f0` which is the first port of the NIC in slot 10.
+
+**NOTE:** `ens10f0` is typically the first port of the OCP 25Gb card that
+the node PXE boots.
+
+**IMPORTANT!** The first interface in the list must be the `nmn0` interface which is configured during the initial image boot, typically `ens10f0`.  This is required because the MAC address of the `nmn0` interface is the MAC associated with the IP address of the UAN.  The bonded `nmnb0` interface and the bond slaves will assume this MAC and the IP address of `nmn0` to preserve connectivity.
+
+The second interface is typically the first port of a different 25Gb NIC for resiliency.
+
+The default values of `uan_nmn_bond_slaves` are shown here.  They may need to be changed to match the actual node cabling and NIC configuration.
+
+```yaml
+uan_nmn_bond_slaves:
+  - "ens10f0"
+  - "ens1f0"
+```
+
+`uan_can_setup`
 
 `uan_can_setup` is a boolean variable controlling the configuration of user
 access to UAN nodes.  When true, user access is configured over either the
@@ -180,7 +212,28 @@ The default value of `uan_can_setup` is `no`.
 uan_can_setup: no
 ```
 
-### `uan_customer_default_route`
+`uan_can_bond_slaves`
+
+`uan_can_bond_slaves` is a list of the interfaces to use as the bond slave pair when `uan_can_setup` is true, `uan_nmn_bond` is true, and the Customer Access Network (CAN) is configured on the system.  This variable is ignored if `uan_nmn_bond` is false.
+
+The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f1` which is the second port of the NIC in slot 10.
+
+**NOTE:** `ens10f1` is typically the second port of the OCP 25Gb card and is used as one of the bond slaves in the CAN `bond0` interface.
+
+The second interface is typically the second port of a different 25Gb NIC for resiliency.
+
+The default values of `uan_can_bond_slaves` are shown here.  They may need to be changed to match the actual node cabling and NIC configuration.
+
+```yaml
+uan_can_bond_slaves:
+  - "ens10f1"
+  - "ens1f1"
+```
+
+`uan_customer_default_route`^M
+
+
+`uan_customer_default_route`
 
 `uan_customer_default_route` is a boolean variable that allows the default route
 to be set by the `customer_uan_routes` data when `uan_can_setup` is true.

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -5,7 +5,7 @@
     <topicmeta>
         <shortdesc>This publication provides instructions and examples for managing and troubleshooting User Access Nodes (UANs) on an HPE Cray EX supercomputer.</shortdesc>
         <data name="pubsnumber" value="S-8033"></data>
-		<data name="edition" value="UAN Software Release 2.5.7"></data>
+		<data name="edition" value="UAN Software Release 2.5.9"></data>
     </topicmeta>
     <topicref href="About_UAN_Administration.md" format="markdown">
         <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install.ditamap
+++ b/docs/portal/developer-portal/uan_install.ditamap
@@ -5,7 +5,7 @@
         <topicmeta>
             <shortdesc>This publication provides instructions and examples for installing the UAN product software on an HPE Cray EX supercomputer.</shortdesc>
             <data name="pubsnumber" value="S-8032"></data>
-			<data name="edition" value="UAN Software Release 2.5.7"></data>
+			<data name="edition" value="UAN Software Release 2.5.9"></data>
         </topicmeta>
     <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
     <topicref href="upgrade/Upgrade_UAN_Software_Product.md" format="markdown"/>

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -47,3 +47,7 @@ When an upgrade is being performed, please review the notable changes for **all*
 
 * A technical preview of a standard SLES image for UAN/Application nodes is included.
 * Support SLES15SP4 COS based images
+
+## UAN 2.5.9
+
+* Support for bonding the NMN interfaces on UAN


### PR DESCRIPTION
#### Summary and Scope
This PR contains changes to UAN docs for the UAN 2.5.9 release which adds support for NMN bonding.

With this change the proper hugo_toc.json for the release is added for Hugo doc builds.