### PR TITLE
Add CVE-2023-0461 mitigation to 2.5.9

### DIFF
--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -56,7 +56,8 @@
         "Configure_Interfaces_on_UANs.md",
         "Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md",
         "UAN_Ansible_Roles.md",
-        "Boot_UANs.md"
+        "Boot_UANs.md",
+        "CVE_2023_0461.md"
     ]
   },
   {
@@ -90,6 +91,10 @@
   {
     "title": "Boot UANs",
     "weight": 48
+  },
+  {
+    "title": "Mitigation for CVE-2023-0461",
+    "weight": 49
   },
   {
     "title": "Advanced",

--- a/docs/portal/developer-portal/operations/CVE_2023_0461.md
+++ b/docs/portal/developer-portal/operations/CVE_2023_0461.md
@@ -23,7 +23,7 @@ The mitigation script provided below will perform the following actions:
 1. Unload `bonding` and `tls` kernel modules provided `mlx5_core` is not present
 1. Fail if `mlx5_core` is detected to highlight that the mititagtion failed
 
-*Important*: This mitigation is intend for UANs that meet the following criteria:
+**Important**: This mitigation is intend for UANs that meet the following criteria:
 
 * The UANs are connected to HPE Aruba Networking switches (`lcap-individual` must be set for other switch types to allow for unbonded CAN connections)
 * The UANs use HPE Slingshot HSN NICs and not Mellanox ConnectX-5 HSN NICs.
@@ -71,10 +71,10 @@ index 0000000..1ced634
 +fi
 +
 +exit 0
-diff --git a/ansible/site.yml b/ansible/site.yml
+diff --git a/site.yml b/site.yml
 index 7c8f5fc..419321e 100644
---- a/ansible/site.yml
-+++ b/ansible/site.yml
+--- a/site.yml
++++ b/site.yml
 @@ -103,6 +103,9 @@
          loop_var: gpu
        when: not cray_cfs_image|default(false)|bool and

--- a/docs/portal/developer-portal/operations/CVE_2024_0461.md
+++ b/docs/portal/developer-portal/operations/CVE_2024_0461.md
@@ -1,0 +1,90 @@
+
+# Mitigation for CVE-2023-0461
+
+## Description
+
+ There is a use-after-free vulnerability in the Linux Kernel which can be exploited to achieve local privilege escalation. To reach the vulnerability, kernel configuration flag CONFIG_TLS or CONFIG_XFRM_ESPINTCP has to be configured, but the operation does not require any privilege. There is a use-after-free bug of icsk_ulp_data of a struct inet_connection_sock. When CONFIG_TLS is enabled, users can install a tls context (struct tls_context) on a connected tcp socket. The context is not cleared if this socket is disconnected and reused as a listener. If a new socket is created from the listener, the context is inherited and vulnerable. The setsockopt TCP_ULP operation does not require any privilege. We recommend upgrading past commit 2c02d41d71f90a5168391b6a5f2954112ba2307c
+
+[CVE-2023-0461](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0461)
+
+Current status from SUSE:
+https://www.suse.com/security/cve/CVE-2023-0461.html
+
+## Mitigation
+
+While the underlying CVE is being addressed by SUSE, UANs can mitigate this issue by unbonding the CAN (if it is being used), and unloading the TLS kernel module after blocking the kernel from being loaded again.
+
+The mitigation script provided below will perform the following actions:
+
+1. Select the first `BONDING_SLAVE0` from `ifcfg-bond0` if it exists
+1. Replace `bond0` in `ifcfg-can0` with the `BONDING_SLAVE0` interface
+1. Reload interfaces
+1. Add a blacklist for the tls module
+1. Unload `bonding` and `tls` kernel modules provided `mlx5_core` is not present
+1. Fail if `mlx5_core` is detected to highlight that the mititagtion failed
+
+*Important*: This mitigation is intend for UANs that meet the following criteria:
+
+* The UANs are connected to HPE Aruba Networking switches (`lcap-individual` must be set for other switch types to allow for unbonded CAN connections)
+* The UANs use HPE Slingshot HSN NICs and not Mellanox ConnectX-5 HSN NICs.
+
+## Procedure
+
+Update the active CFS configuration with the following changes so that Node Personalization applies the change to the UANs:
+
+```bash
+diff --git a/mitigate-uan-cve-2023-0461.sh b/mitigate-uan-cve-2023-0461.sh
+new file mode 100755
+index 0000000..1ced634
+--- /dev/null
++++ b/mitigate-uan-cve-2023-0461.sh
+@@ -0,0 +1,32 @@
++#!/bin/bash
++
++# Select the BONDING_SLAVE0 as the unbonded interface and create a new ifcfg file
++if [ -f /etc/sysconfig/network/ifcfg-bond0 ] && grep -q BONDING_SLAVE0 /etc/sysconfig/network/ifcfg-bond0; then
++  ifname=$(grep BONDING_SLAVE0 /etc/sysconfig/network/ifcfg-bond0 | awk -F= '{print $2}' | tr -d \'\")
++  sed -i -e "s/bond0/$ifname/g" /etc/sysconfig/network/ifcfg-can0
++  cat << EOF > /etc/sysconfig/network/ifcfg-$ifname
++STARTMODE='auto'
++BOOTPROTO='static'
++EOF
++  rm /etc/sysconfig/network/ifcfg-bond0
++fi
++
++# Reload interfaces to bring up the unbonded can
++wicked ifreload all
++
++# Create a blacklist file and unload bonding tls
++cat << EOF > /etc/modprobe.d/66-blacklist-tls.conf
++blacklist tls
++install tls /bin/true
++EOF
++
++# This will fail on mellanox systems as mlx5_core depends on tls
++# Failure of this script will in
++if modinfo mlx5_core &> /dev/null; then
++  rmmod bonding tls
++else
++  echo "Can't rmmod tls as mlx5_core depends on it"
++  exit 1
++fi
++
++exit 0
+diff --git a/ansible/site.yml b/ansible/site.yml
+index 7c8f5fc..419321e 100644
+--- a/ansible/site.yml
++++ b/ansible/site.yml
+@@ -103,6 +103,9 @@
+         loop_var: gpu
+       when: not cray_cfs_image|default(false)|bool and
+             not ansible_check_mode
++    - name: Bond interface mitigation
++      script: mitigate-uan-cve-2023-0461.sh
++      when: not cray_cfs_image|default(false)|bool
+ 
+ - hosts: Compute
+   gather_facts: yes
+```
+
+Once UAN images are built to address the CVE, this mitigation script should be removed.

--- a/docs/portal/developer-portal/uan_admin.ditamap
+++ b/docs/portal/developer-portal/uan_admin.ditamap
@@ -21,6 +21,7 @@
             format="markdown"/>
         <topicref href="operations/Mount_a_New_File_System_on_an_UAN.md" format="markdown"/>
         <topicref href="operations/Boot_UANs.md" format="markdown"/>
+        <topicref href="operations/CVE_2023_0461.md" format="markdown"/>
     </topicref>
     <topicref href="Advanced_Administrative_Tasks.md" format="markdown">
         <topicref href="advanced/Customizing_UAN_Images_Manually.md" format="markdown"/>

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -51,3 +51,4 @@ When an upgrade is being performed, please review the notable changes for **all*
 ## UAN 2.5.9
 
 * Support for bonding the NMN interfaces on UAN
+* Mitigation for CVE-2023-0461


### PR DESCRIPTION
#### Summary and Scope
This PR adds the CVE-2023-0461 mitigation to the UAN 2.5.9 documentation.

NOTE: This procedure must be testing before merging to release/uan-2.5.9.