### PR TITLE
fix title generation

### DIFF
--- a/docs/hugo/docs-uan/bin/lib/content_prep
+++ b/docs/hugo/docs-uan/bin/lib/content_prep
@@ -2,52 +2,56 @@
 
 function make_new_title() {
     # Remove "CSM", extra spaces, number signs, html, and colons.
-    # Change underscores to spaces. Capitalize acronyms and every word.
+    # Change underscores to spaces. Capitalize acronyms.
     echo "${1}" | \
     sed -r 's`^#+ ``' | \
-    sed -r 's`CSM``' | sed 's`csm``g' | sed 's`()``g' | \
+    sed -r 's`CSM\b``' | sed 's`csm\b``g' | sed 's`()``g' | \
     sed -r 's`^ +``' | \
     sed 's`:``g' | \
     sed 's`_` `g' | \
     sed -r 's`<.*>.*<.*>``' | \
     sed 's`\\(`(`g' | sed 's`\\)`)`g' | \
-    awk '{for (i=1; i<=NF; ++i) { $i=toupper(substr($i,1,1)) tolower(substr($i,2)); } print }' | \
-    sed -r 's`[S,s]ls`SLS`' | \
-    sed -r 's`[T,s]ls`TLS`' | \
-    sed -r 's`[P,p]ki`PKI`' | \
-    sed -r 's`[S,s]sh`SSH`' | \
-    sed -r 's`[U,u]an`UAN`' | \
-    sed -r 's`[U,u]ai`UAI`' | \
-    sed -r 's`[U,u]as`UAS`' | \
-    sed -r 's`[B,b]mc`BMC`' | \
+    sed -r 's`[S,s]ls\b`SLS`' | \
+    sed -r 's`[T,s]ls\b`TLS`' | \
+    sed -r 's`[P,p]ki\b`PKI`' | \
+    sed -r 's`[S,s]sh\b`SSH`' | \
+    sed -r 's`[U,u]an\b`UAN`' | \
+    sed -r 's`[U,u]ans\b`UANs`' | \
+    sed -r 's`[U,u]ai\b`UAI`' | \
+    sed -r 's`[U,u]ais\b`UAIs`' | \
+    sed -r 's`[U,u]as\b`UAS`' | \
+    sed -r 's`[B,b]mc\b`BMC`' | \
     sed -r 's`[H,h]ttps`HTTPS`' | \
     sed -r 's`[H,h]ttp`HTTP`' | \
     sed -r 's`[L,l]dap`LDAP`' | \
-    sed -r 's`[R,r]eds`REDS`' | \
-    sed -r 's`[M,m]eds`MEDS`' | \
-    sed -r 's`[N,n]tp`NTP`' | \
-    sed -r 's`[C,c]apmc`CAPMC`' | \
-    sed -r 's`[K,k]vm`KVM`' | \
-    sed -r 's`[G,g]pu`GPU`' | \
-    sed -r 's`[H,h]sn`HSN`' | \
-    sed -r 's`[H,h]sm`HSM`' | \
-    sed -r 's`[N,n]ic`NIC`' | \
-    sed -r 's`[N,n]cn`NCN`' | \
-    sed -r 's`[B,b]gp`BGP`' | \
-    sed -r 's`[D,d]ns`DNS`' | \
-    sed -r 's`[D,d]hcp`DHCP`' | \
-    sed -r 's`[H,h]pe`HPE`' | \
-    sed -r 's`[I,i]ms`IMS`' | \
-    sed -r 's`[F,f]as`FAS`' | \
-    sed -r 's`[C,c]fs`CFS`' | \
-    sed -r 's`[B,b]os`BOS`' | \
-    sed -r 's`[C,c]rus`CRUS`' | \
-    sed -r 's`[C,c]an`CAN`' | \
-    sed -r 's`[P,p]xe`PXE`' | \
-    sed -r 's`[I,i]lo`iLO`' | \
-    sed -r 's`[B,b]ios`BIOS`' | \
-    sed -r 's`[C,c]os`COS`' | \
-    sed -r 's`[A,a]cl`ACL`'
+    sed -r 's`[R,r]eds\b`REDS`' | \
+    sed -r 's`[M,m]eds\b`MEDS`' | \
+    sed -r 's`[N,n]tp\b`NTP`' | \
+    sed -r 's`[C,c]apmc\b`CAPMC`' | \
+    sed -r 's`[K,k]vm\b`KVM`' | \
+    sed -r 's`[G,g]pu\b`GPU`' | \
+    sed -r 's`[H,h]sn\b`HSN`' | \
+    sed -r 's`[H,h]sm\b`HSM`' | \
+    sed -r 's`[N,n]ic\b`NIC`' | \
+    sed -r 's`[N,n]cn\b`NCN`' | \
+    sed -r 's`[B,b]gp\b`BGP`' | \
+    sed -r 's`[D,d]ns\b`DNS`' | \
+    sed -r 's`[D,d]hcp\b`DHCP`' | \
+    sed -r 's`[H,h]pe\b`HPE`' | \
+    sed -r 's`[I,i]ms\b`IMS`' | \
+    sed -r 's`[F,f]as\b`FAS`' | \
+    sed -r 's`[C,c]fs\b`CFS`' | \
+    sed -r 's`[B,b]os\b`BOS`' | \
+    sed -r 's`[C,c]rus\b`CRUS`' | \
+    sed -r 's`[C,c]an\b`CAN`' | \
+    sed -r 's`[P,p]xe\b`PXE`' | \
+    sed -r 's`[I,i]lo\b`iLO`' | \
+    sed -r 's`[B,b]ios\b`BIOS`' | \
+    sed -r 's`[C,c]os\b`COS`' | \
+    sed -r 's`[S,s]les\b`SLES`' | \
+    sed -r 's`[P,p]am\b`PAM`' | \
+    sed -r 's`[A,a]cl\b`ACL`' | \
+    tr -d "\r"
 }
 
 function transform_links() {
@@ -82,7 +86,9 @@ function gen_hugo_yaml() {
     rm -f /tmp/have_weight
     cat ${HUGO_TOC} | jq -r '.[]|[.title, .weight]|@tsv' |
         while IFS=$'\t' read -r title weight; do
-            if [[ "$title" == "$1" ]]; then
+            toc_title=$(echo "$title" | awk '{print tolower($0)}')
+            given_title=$(echo "$1" | awk '{print tolower($0)}')
+            if [[ "${toc_title}" == "${given_title}" ]]; then
                 myweight="$weight"
                 gen_weighted_header "$1" "$myweight"
                 touch /tmp/have_weight

--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -21,19 +21,19 @@
     ]
   },
   {
-    "title": "Prepare For UAN Product Installation",
+    "title": "Prepare for UAN Product Installation",
     "weight": 21
   },
   {
-    "title": "Configure The BMC For UANs With iLO",
+    "title": "Configure the BMC for UANs with iLO",
     "weight": 22
   },
   {
-    "title": "Configure The BIOS Of An HPE UAN",
+    "title": "Configure the BIOS of an HPE UAN",
     "weight": 23
   },
   {
-    "title": "Configure The BIOS Of A Gigabyte UAN",
+    "title": "Configure the BIOS of a Gigabyte UAN",
     "weight": 24
   },
   { 
@@ -65,7 +65,7 @@
     "weight": 41
   },
   {
-    "title": "Build A New UAN Image Using A COS Recipe",
+    "title": "Build a New UAN Image Using a COS Recipe",
     "weight": 42
   },
   {
@@ -73,15 +73,15 @@
     "weight": 43
   },
   {
-    "title": "Mount A New File System On A UAN",
+    "title": "Mount a New File System on a UAN",
     "weight": 44
   },
   {
-    "title": "Configure Interfaces On UANs",
+    "title": "Configure Interfaces on UANs",
     "weight": 45
   },
   {
-    "title": "Configure Pluggable Authentication Modules (pam) On UANs",
+    "title": "Configure Pluggable Authentication Modules (PAM) on UANs",
     "weight": 46
   },
   {
@@ -93,7 +93,7 @@
     "weight": 48
   },
   {
-    "title": "Mitigation For Cve-2023-0461",
+    "title": "Mitigation for CVE-2023-0461",
     "weight": 49
   },
   {
@@ -113,19 +113,19 @@
     "weight": 51
   },
   {
-    "title": "Enabling The Customer Access Network (CAN) Or The Customer High Speed Network (chn)",
+    "title": "Enabling the Customer Access Network (CAN) or the Customer High Speed Network (CHN)",
     "weight": 52
   },
   {
-    "title": "Repurposing A Compute Node As A UAN",
+    "title": "Repurposing a Compute Node as a UAN",
     "weight": 53
   },
   {
-    "title": "Booting An Application Node With A Sles Image (Technical Preview)",
+    "title": "Booting an Application Node with a SLES Image (Technical Preview)",
     "weight": 54
   },
   {
-    "title": "Configuring A UAN For K3s (Technical Preview)",
+    "title": "Configuring a UAN for K3s (Technical Preview)",
     "weight": 55
   },
   {
@@ -135,6 +135,10 @@
     "toc": [
       "Notable_Changes.md"
     ]
+  },
+  {
+    "title": "Notable Changes",
+    "weight": 61 
   },
   {
     "title": "Troubleshooting",
@@ -151,7 +155,7 @@
     "weight": 71
   },
   {
-    "title": "Troubleshoot UAN CFS And Network Configuration Issues",
+    "title": "Troubleshoot UAN CFS and Network Configuration Issues",
     "weight": 72
   },
   {
@@ -165,5 +169,9 @@
     "toc": [
         "test-plan.md"
     ]
+  },
+  {
+    "title": "Test Plan for User Access Node (UAN) and Repurposed Compute Node as UAN",
+    "weight": 81
   }
 ]


### PR DESCRIPTION
#### Summary and Scope

This PR fixes some errors found in title generation from the markdown files and generation of the sidebar ordering which is based on the hugo doc front matter inserted in each index.md file.

index.md files were being generated with every word in the title being capitalized and acronym capitalization not being restricted to word boundaries which resulted in words like "(Technical Preview) being rendered as (techNICal Preview)".

There was also a case where an errant "\r" character in a markdown file resulted in that title not being matched and then not being weighted properly for sidebar ordering in hugo.