### PR TITLE
Fix toc for 2.5.10

### DIFF
--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -21,19 +21,19 @@
     ]
   },
   {
-    "title": "Prepare For UAN Product Installation",
+    "title": "Prepare for UAN Product Installation",
     "weight": 21
   },
   {
-    "title": "Configure The BMC For UANs With iLO",
+    "title": "Configure the BMC for UANs with iLO",
     "weight": 22
   },
   {
-    "title": "Configure The BIOS Of An HPE UAN",
+    "title": "Configure the BIOS of an HPE UAN",
     "weight": 23
   },
   {
-    "title": "Configure The BIOS Of A Gigabyte UAN",
+    "title": "Configure the BIOS of a Gigabyte UAN",
     "weight": 24
   },
   { 
@@ -64,7 +64,7 @@
     "weight": 41
   },
   {
-    "title": "Build A New UAN Image Using A COS Recipe",
+    "title": "Build a New UAN Image Using a COS Recipe",
     "weight": 42
   },
   {
@@ -72,15 +72,15 @@
     "weight": 43
   },
   {
-    "title": "Mount A New File System On A UAN",
+    "title": "Mount a New File System on a UAN",
     "weight": 44
   },
   {
-    "title": "Configure Interfaces On UANs",
+    "title": "Configure Interfaces on UANs",
     "weight": 45
   },
   {
-    "title": "Configure Pluggable Authentication Modules (pam) On UANs",
+    "title": "Configure Pluggable Authentication Modules (PAM) on UANs",
     "weight": 46
   },
   {
@@ -108,19 +108,19 @@
     "weight": 51
   },
   {
-    "title": "Enabling The Customer Access Network (CAN) Or The Customer High Speed Network (chn)",
+    "title": "Enabling the Customer Access Network (CAN) or the Customer High Speed Network (CHN)",
     "weight": 52
   },
   {
-    "title": "Repurposing A Compute Node As A UAN",
+    "title": "Repurposing a Compute Node as a UAN",
     "weight": 53
   },
   {
-    "title": "Booting An Application Node With A Sles Image (Technical Preview)",
+    "title": "Booting an Application Node with a Sles Image (Technical Preview)",
     "weight": 54
   },
   {
-    "title": "Configuring A UAN For K3s (Technical Preview)",
+    "title": "Configuring a UAN for K3s (Technical Preview)",
     "weight": 55
   },
   {
@@ -160,7 +160,7 @@
     "weight": 71
   },
   {
-    "title": "Troubleshoot UAN CFS And Network Configuration Issues",
+    "title": "Troubleshoot UAN CFS and Network Configuration Issues",
     "weight": 72
   },
   {
@@ -175,5 +175,13 @@
         "test-plan.md",
         "K3s_Test_Plan.md"
     ]
+  },
+  {
+    "title": "Test Plan for User Access Node (UAN) and Repurposed Compute Node as UAN",
+    "weight": 81
+  },
+  {
+    "title": "Test Plan for UAIs on UANs (K3s Verification)",
+    "weight": 82
   }
 ]

--- a/docs/portal/developer-portal/test-plan/K3s_Test_Plan.md
+++ b/docs/portal/developer-portal/test-plan/K3s_Test_Plan.md
@@ -1,3 +1,5 @@
+# Test Plan for UAIs on UANs (K3s Verification)
+
 ## Overview
 Perform this procedure to verify that K3s on UANs can launch the services necessary to replicate UAIs as Podman containers. 
 

--- a/docs/portal/developer-portal/upgrade/Upgrade_UAN_Software_Product.md
+++ b/docs/portal/developer-portal/upgrade/Upgrade_UAN_Software_Product.md
@@ -1,4 +1,4 @@
-# Upgrade UAN software product
+# Upgrade UAN Software Product
 
 Follow upgrade instructions in [*HPE Cray EX System Software Getting Started Guide (S-8000)*](https://www.hpe.com/support/ex-S-8000) to upgrade the UAN software product. Those instructions provide:
 


### PR DESCRIPTION
#### Summary and Scope
This PR fixes the hugo_toc.json file for proper title capitalization in the 2.5.10 release branch.

NOTE: After merge, the v2.5.10 tag needs to be moved to this commit.