### PR TITLE
changed xref targets to be the whole file, not the first section.

### DIFF
--- a/docs/portal/developer-portal/advanced/Enabling_K3s.md
+++ b/docs/portal/developer-portal/advanced/Enabling_K3s.md
@@ -210,7 +210,7 @@ This is an example that should be tailored to the desired configuration. See the
 For more information HAProxy configurations, see [HAProxy Configuration](<https://docs.haproxy.org/2.7/configuration.html>)
 
 To enable additional instances of HAProxy representing alternate configurations, add a new element to the list `uan_haproxy`.
-### SSHD Configuration:
+### SSHD Configuration
 The role `uan_sshd` runs in the playbook `k3s.yml` to start and configure new instances of SSHD to respond to HAProxy forwarded connections. Each new instance of SSHD is defined in `vars/uan_sshd.yml` as an element in the list `uan_sshd_configs`:
 ```yaml
 uan_sshd_configs:

--- a/docs/portal/developer-portal/advanced/Enabling_K3s.md
+++ b/docs/portal/developer-portal/advanced/Enabling_K3s.md
@@ -207,10 +207,10 @@ uan_haproxy:
 ```
 This is an example that should be tailored to the desired configuration. See the [SSHD Configuration](#sshd-configuration) section to create new instances of SSHD to respond to HAProxy connections outside of the standard SSHD running on port 22.
 
-For more information HAProxy configurations, see [HAProxy Configuration](<https://docs.haproxy.org/2.7/configuration.html>
+For more information HAProxy configurations, see [HAProxy Configuration](<https://docs.haproxy.org/2.7/configuration.html>)
 
 To enable additional instances of HAProxy representing alternate configurations, add a new element to the list `uan_haproxy`.
-### SSHD Configuration
+### SSHD Configuration:
 The role `uan_sshd` runs in the playbook `k3s.yml` to start and configure new instances of SSHD to respond to HAProxy forwarded connections. Each new instance of SSHD is defined in `vars/uan_sshd.yml` as an element in the list `uan_sshd_configs`:
 ```yaml
 uan_sshd_configs:

--- a/docs/portal/developer-portal/advanced/Enabling_K3s.md
+++ b/docs/portal/developer-portal/advanced/Enabling_K3s.md
@@ -68,8 +68,7 @@ The following steps should be completed prior to configuring the UAN with K3s.
      ]
    }
 
-### Podman Image
-1. Place a container image suitable for users within a container image registry accessible from the UAN.
+1. Place a Podman container image suitable for users within a container image registry accessible from the UAN.
 
 ## Configuring with Configuration Framework Service (CFS)
 
@@ -208,7 +207,7 @@ uan_haproxy:
 ```
 This is an example that should be tailored to the desired configuration. See the [SSHD Configuration](#sshd-configuration) section to create new instances of SSHD to respond to HAProxy connections outside of the standard SSHD running on port 22.
 
-For more information HAProxy configurations, see [HAProxy Configuration](#https://docs.haproxy.org/2.7/configuration.html).
+For more information HAProxy configurations, see [HAProxy Configuration](<https://docs.haproxy.org/2.7/configuration.html>
 
 To enable additional instances of HAProxy representing alternate configurations, add a new element to the list `uan_haproxy`.
 ### SSHD Configuration

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md
@@ -4,7 +4,7 @@ Perform this procedure to configure the network interface and boot settings requ
 
 Before the UAN product can be installed on HPE UANs, specific network interface and boot settings must be configured in the BIOS.
 
-Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md#configure-the-bmc-for-uans-with-ilo) before performing this procedure.
+Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md) before performing this procedure.
 
 1. Force a UAN to reboot into the BIOS.
 

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md
@@ -2,7 +2,7 @@
 
 Perform this procedure to enable the IPMI/DCMI settings on an HPE UAN that are necessary to continue UAN product installation on an HPE Cray EX supercomputer.
 
-Perform the first three steps of [Prepare for UAN Product Installation](Prepare_for_UAN_Product_Installation.md#prepare-for-uan-product-installation) before performing this procedure.
+Perform the first three steps of [Prepare for UAN Product Installation](Prepare_for_UAN_Product_Installation.md) before performing this procedure.
 
 1. Create the SSH tunnel necessary to access the BMC web GUI interface.
 

--- a/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
+++ b/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
@@ -18,12 +18,12 @@ Install and configure the COS product before performing this procedure.
 
 4. Configure the BMC of the UAN.
 
-   Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md#configure-the-bmc-for-uans-with-ilo) if the UAN is a HPE server with an iLO.
+   Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md) if the UAN is a HPE server with an iLO.
 
 5. Configure the BIOS of the UAN.
 
-    - Perform [Configure the BIOS of an HPE UAN](Configure_the_BIOS_of_an_HPE_UAN.md#configure-the-bios-of-an-hpe-uan) if the UAN is a HPE server with an iLO.
-    - Perform [Configure the BIOS of a Gigabyte UAN](Configure_the_BIOS_of_a_Gigabyte_UAN.md#configure-the-bios-of-a-gigabyte-uan) if the UAN is a Gigabyte server.
+    - Perform [Configure the BIOS of an HPE UAN](Configure_the_BIOS_of_an_HPE_UAN.md) if the UAN is a HPE server with an iLO.
+    - Perform [Configure the BIOS of a Gigabyte UAN](Configure_the_BIOS_of_a_Gigabyte_UAN.md) if the UAN is a Gigabyte server.
 
 6. Verify that the firmware for each UAN BMC meets the specifications.
 
@@ -87,4 +87,4 @@ Install and configure the COS product before performing this procedure.
 
        If a console connection is not present, the install may continue, but a console connection should be established before attempting to boot the UAN.
 
-Next, install the UAN product by performing the procedure [Install the UAN Product Stream](../install/Install_the_UAN_Product_Stream.md#install-the-uan-product-stream).
+Next, install the UAN product by performing the procedure [Install the UAN Product Stream](../install/Install_the_UAN_Product_Stream.md).

--- a/docs/portal/developer-portal/operations/About_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/About_UAN_Configuration.md
@@ -20,7 +20,7 @@ The UAN-specific roles involved in post-boot UAN node configuration are:
 
 The UAN roles in site.yml are required and must not be removed, with exception of `uan_ldap` if the site is using some other method of user authentication. The `uan_ldap` may also be skipped by setting the value of `uan_ldap_setup` to `no` in a `group_vars` or `host_vars` configuration file.
 
-For more information about these roles, see [UAN Ansible Roles](UAN_Ansible_Roles.md#uan-ansible-roles).
+For more information about these roles, see [UAN Ansible Roles](UAN_Ansible_Roles.md).
 
 ## UAN network configuration
 
@@ -40,7 +40,7 @@ The `uan_interfaces` role configures the interfaces on the UAN nodes in three ph
         2. CHN: Implement the CHN interface on the HSN
 3. Setup customer-defined networks
 
-See [Configure Interfaces on UANs](Configure_Interfaces_on_UANs.md#configure-interfaces-on-uans) for detailed instructions.
+See [Configure Interfaces on UANs](Configure_Interfaces_on_UANs.md) for detailed instructions.
 
 ### UAN LDAP network requirements
 

--- a/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
+++ b/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
@@ -8,7 +8,7 @@ Perform the following before starting this procedure:
 - Install the COS, Slingshot, and UAN product streams.
 - Initialize the cray administrative CLI.
 
-In the COS recipe for 2.2, several dependencies have been removed, this includes Slingshot, DVS, and Lustre. Those packages are now installed during CFS Image Customization. More information on this change is covered in the [Create UAN Boot Images](Create_UAN_Boot_Images.md#create-boot-images) procedure.
+In the COS recipe for 2.2, several dependencies have been removed, this includes Slingshot, DVS, and Lustre. Those packages are now installed during CFS Image Customization. More information on this change is covered in the [Create UAN Boot Images](Create_UAN_Boot_Images.md) procedure.
 
 1. Identify the COS image recipe to base the UAN image on. Select the recipe that matches the version of COS that the compute nodes will be using.
 
@@ -45,4 +45,4 @@ In the COS recipe for 2.2, several dependencies have been removed, this includes
    ncn-m001# cray ims jobs create --job-type create --public-key-id $IMS_PUBLIC_KEY --image-root-archive-name $IMS_ARCHIVE_NAME --artifact-id $IMS_RECIPE_ID
    ```
 
-4. Perform [Create UAN Boot Images](Create_UAN_Boot_Images.md#create-boot-images) to run CFS Image Customization on the resulting image.
+4. Perform [Create UAN Boot Images](Create_UAN_Boot_Images.md#) to run CFS Image Customization on the resulting image.

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -119,7 +119,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
     The following example shows how to add a `vars.yml` file containing site-specific configuration values to the `Application_UAN` group variable location.
 
-    These and other Ansible files do not necessarily need to be modified for UAN image creation. See [About UAN Configuration](About_UAN_Configuration.md#about-uan-configuration) for instructions for site-specific UAN configuration, including CAN/CHN configuration.
+    These and other Ansible files do not necessarily need to be modified for UAN image creation. See [About UAN Configuration](About_UAN_Configuration.md) for instructions for site-specific UAN configuration, including CAN/CHN configuration.
 
     ```bash
     ncn-m001# vim group_vars/Application_UAN/vars.yml
@@ -259,4 +259,4 @@ If changes are necessary to complete `sat bootprep` with the provided input file
 
 Once `sat bootprep` completes successfully, save the input file to a known location. This input file will be useful to regenerate artifacts as changes are made or different product layers are added.
 
-Finally, perform [Boot UANs](Boot_UANs.md#boot-uans) to boot the UANs with the new BOS session template.
+Finally, perform [Boot UANs](Boot_UANs.md) to boot the UANs with the new BOS session template.

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Boot_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Boot_Issues.md
@@ -31,7 +31,7 @@ Dracut failures are often caused by the wrong interface being named `nmn0`, or t
 
 When dracut starts, it renames the network device named by the `ifmap=netX:nmn0` kernel parameter to `nmn0`. This interface is the only one dracut will enable DHCP on. The `ip=nmn0:dhcp` kernel parameter limits dracut to DHCP only `nmn0`. The ifmap value must be set correctly in the `kernel_parameters` field of the BOS session template.
 
-See [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md#create-uan-boot-images) for details on how to configure the BOS session template. For UAN nodes that have more than one PCI card installed, `ifmap=net2:nmn0` is the correct setting. If only one PCI card is installed, `ifmap=net0:nmn0` is normally the correct setting.
+See [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) for details on how to configure the BOS session template. For UAN nodes that have more than one PCI card installed, `ifmap=net2:nmn0` is the correct setting. If only one PCI card is installed, `ifmap=net0:nmn0` is normally the correct setting.
 
 UANs require CPS and DVS to boot from images. These services are configured in dracut to retrieve the rootfs and mount it. If the image fails to download, check that DVS and CPS are both healthy, and DVS is running on all worker nodes. Run the following commands to check DVS and CPS:
 


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3187

**IMPORTANT** From now on, avoid using cross references of the form `[LINK TEXT](TARGET_FILE.md#TARGET_SECTION_WITHIN_TARGET_FILE)` . Use `[LINK TEXT](TARGET_FILE.md)` instead. In the rare cases we need to get more specific, we can break up the file into separate ones and point to one of the new, smaller files.

In all the cases I fixed, the `#TARGET_SECTION_WITHIN_TARGET_FILE` was just the name of the Level 1 header anyway, so it had the same effect as just referencing the TARGET_FILE.

##### Issue Type

- Docs Pull Request

Fixes nearly all broken cross-references in the guide PDFs generated by HPESC. One known exception: the "Create UAN Boot Images" procedure still contains a broken link to "Build a New UAN Image Using a COS Recipe". I'm so far unable to determine why.

The "fix" is removing the reference to the first section of the target file. The process HPESC uses to convert from the separate HTML files to the single PDF file can't handle that link format.

HTML links on HPESC (and very likely on the github.io page) were working before, and still work after, this change.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on my local system by building docs and publishing to the ITG portal, then generating PDFs of the guides and testing the links. 

#### Risks and Mitigations
 
Very low risk to Markdown and HPESC output formats. Also low risk to the Hugo-generated docs because we're still using a standard Markdown link syntax.
