### PR TITLE
CASMUSER-3189

### DIFF
--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -49,7 +49,7 @@
     "dir": "operations",
     "weight": 40,
     "toc": [
-        "About_UAN_Configuration.md",
+        "Basic_UAN_Configuration.md",
         "Build_a_New_UAN_Image_Using_the_COS_Recipe.md",
         "Create_UAN_Boot_Images.md",
         "Mount_a_New_File_System_on_an_UAN.md",
@@ -61,7 +61,7 @@
     ]
   },
   {
-    "title": "About UAN Configuration",
+    "title": "Basic_UAN_Configuration",
     "weight": 41
   },
   {

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -34,7 +34,7 @@ This section describes any UAN details that an administrator may need to be awar
 
 ### update-cfs-config
 
-**Action**: Before executing this stage, any site-local UAN configuration changes should be made so the following stages execute using the desired UAN configuration values. See the [About UAN Configuration](../operations/About_UAN_Configuration.md) section of this documentation for UAN configuration content details. Note that the [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh install scenarios.
+**Action**: Before executing this stage, any site-local UAN configuration changes should be made so the following stages execute using the desired UAN configuration values. See the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section of this documentation for UAN configuration content details. Note that the [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh install scenarios.
 
 ## UAN Content Installed
 
@@ -43,7 +43,7 @@ The following subsections describe the majority of the UAN content installed and
 
 ### Configuration
 
-UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number \(2.6.XX\) to distinguish it from any previously released UAN configuration content. This content is described in detail in the [About UAN Configuration](../operations/About_UAN_Configuration.md) section.
+UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number \(2.6.XX\) to distinguish it from any previously released UAN configuration content. This content is described in detail in the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section.
 
 For application nodes based on COS, the COS compute image is used as the base application node image and two COS CFS layers are required. The first COS CFS layer runs the `cos-application.yml` Ansible playbook and ensures that the COS content is applied as part of the image customization and node personalization processes. This COS CFS layer must precede the UAN CFS layer in the UAN CFS configuration. A second  COS CFS layer running the Ansible playbook, `cos-application-after.yml`, runs after the UAN CFS layer of the UAN CFS configuration to ensure that the application node initrd is rebuilt and that any customer defined filesystems are configured.
 

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -1,6 +1,4 @@
-# About UAN Configuration
-
-This section describes the Ansible playbooks and roles that configure UANs.
+#  Basic UAN Configuration
 
 ## UAN configuration overview
 

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -119,7 +119,7 @@ Replace `PRODUCT_VERSION` and `CRAY_EX_HOSTNAME` in the example commands in this
 
     The following example shows how to add a `vars.yml` file containing site-specific configuration values to the `Application_UAN` group variable location.
 
-    These and other Ansible files do not necessarily need to be modified for UAN image creation. See [About UAN Configuration](About_UAN_Configuration.md) for instructions for site-specific UAN configuration, including CAN/CHN configuration.
+    These and other Ansible files do not necessarily need to be modified for UAN image creation. See [Basic UAN Configuration](Basic_UAN_Configuration.md) for instructions for site-specific UAN configuration, including CAN/CHN configuration.
 
     ```bash
     ncn-m001# vim group_vars/Application_UAN/vars.yml

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md
@@ -3,7 +3,7 @@
 
 Examine the UAN CFS pod logs to help troubleshoot CFS and networking issues on UANs.
 
-Read [About UAN Configuration](../operations/About_UAN_Configuration.md#about-uan-configuration) before starting this procedure.
+Read [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) before starting this procedure.
 
 1. Obtain the name of the CFS session that failed by running the following command on a management or worker NCN:
 

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md
@@ -5,7 +5,7 @@ Perform this procedure to enable `uan_disk_config` to run successfully by erasin
 
 This procedure currently only addresses `uan_disk_config` errors due to existing disk partitions.
 
-Refer to [About UAN Configuration](../operations/About_UAN_Configuration.md#about-uan-configuration) for an explanation of UAN disk configuration.
+Refer to [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) for an explanation of UAN disk configuration.
 
 The most common cause of failure in the `uan_disk_config` role is the disk having been previously configured without a `/scratch` and `/swap` partition. Existing partitions prevent the `parted` command from dividing the disk into those two equal partitions. The solution is to log into the node and run `parted` manually to remove the existing partitions on that disk.
 

--- a/docs/portal/developer-portal/uan_admin_guide.ditamap
+++ b/docs/portal/developer-portal/uan_admin_guide.ditamap
@@ -7,25 +7,24 @@
         <data name="pubsnumber" value="S-8033"></data>
 		<data name="edition" value="UAN Software Release @product_version@"></data>
     </topicmeta>
-    <topicref href="operations/About_UAN_Configuration.md" format="markdown"/>
-    <topicref href="operations/CVE-2023-0461.md" format="markdown"/>
-    <topichead>
-	    <topicmeta><navtitle>Manage UAN Boot Images</navtitle></topicmeta>
+    <topicref href="operations/Basic_UAN_Configuration.md" format="markdown">
+        <topicref href="operations/Configure_Interfaces_on_UANs.md" format="markdown"/>
+        <topicref href="operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md"
+            format="markdown"/>
+        <topicref href="operations/Mount_a_New_File_System_on_an_UAN.md" format="markdown"/>
+        <topicref href="operations/CVE-2023-0461.md" format="markdown"/>
         <topicref href="operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md" format="markdown"/>
         <topicref href="operations/Create_UAN_Boot_Images.md" format="markdown"/>
+        <topicref href="operations/UAN_Ansible_Roles.md" format="markdown"/>
+    </topicref>
+    <topichead navtitle="Advanced UAN Configuration">
         <topicref href="advanced/Customizing_UAN_Images_Manually.md" format="markdown"/>
-        <topicref href="advanced/SLES_Image.md" format="markdown"/>
-</topichead>
-    <topichead navtitle="Configure Network Interfaces">
-        <topicref href="operations/Configure_Interfaces_on_UANs.md" format="markdown"/>
         <topicref href="advanced/Enabling_CAN_CHN.md" format="markdown"/>
+        <topicref href="advanced/Repurposing_Compute_as_UAN.md" format="markdown"/>
+        <topicref href="advanced/SLES_Image.md" format="markdown"/>
+        <topicref href="advanced/Enabling_K3s.md" format="markdown"/>
     </topichead>
-    <topicref href="operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md"
-        format="markdown"/>
-    <topicref href="operations/Mount_a_New_File_System_on_an_UAN.md" format="markdown"/>
     <topicref href="operations/Boot_UANs.md" format="markdown"/>
-    <topicref href="advanced/Repurposing_Compute_as_UAN.md" format="markdown"/>
-    <topicref href="advanced/Enabling_K3s.md" format="markdown"/>
     <topichead>
 	<topicmeta><navtitle>Troubleshooting</navtitle></topicmeta>
         <topicref href="troubleshooting/Troubleshoot_UAN_Boot_Issues.md" format="markdown"/>
@@ -33,9 +32,5 @@
             format="markdown"/>
         <topicref href="troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md"
             format="markdown"/>
-    </topichead>
-    <topichead>
-	<topicmeta><navtitle>Reference</navtitle></topicmeta>
-        <topicref href="operations/UAN_Ansible_Roles.md" format="markdown"/>
     </topichead>
 </map>

--- a/docs/portal/developer-portal/uan_install_guide.ditamap
+++ b/docs/portal/developer-portal/uan_install_guide.ditamap
@@ -7,21 +7,19 @@
             <data name="pubsnumber" value="S-8032"></data>
 			<data name="edition" value="UAN Software Release @product_version@"></data>
         </topicmeta>
-    <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
-    <topichead>
-	    <topicmeta><navtitle>Hardware and Software Prerequisites</navtitle></topicmeta>    
-        <topicref href="installation_prereqs/Prepare_for_UAN_Product_Installation.md"
-            format="markdown"/>
-        <topicref href="installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md"
-            format="markdown"/>
-        <topicref href="installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md" format="markdown"/>
+    <topicref href="installation_prereqs/Prepare_for_UAN_Product_Installation.md" format="markdown">
         <topicref href="installation_prereqs/Configure_the_BIOS_of_a_Gigabyte_UAN.md"
             format="markdown"/>
-    </topichead>
-    <topicref href="install/Install_the_UAN_Product_Stream.md" format="markdown"/>
-    <topicref href="operations/About_UAN_Configuration.md" format="markdown">
+        <topicref href="installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md" format="markdown"/>
+        <topicref href="installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md"
+            format="markdown"/>
+    </topicref>
+    <topicref href="install/Install_the_UAN_Product_Stream.md" format="markdown">
+        <topicref href="upgrade/Notable_Changes.md" format="markdown"/>
+    </topicref>
+    <topicref href="operations/Basic_UAN_Configuration.md" format="markdown">
         <topicref href="operations/Configure_Interfaces_on_UANs.md" format="markdown"/>
         <topicref href="advanced/Enabling_CAN_CHN.md" format="markdown"/>
-        <topicref href="operations/UAN_Ansible_Roles.md" format="markdown"/>
     </topicref>
+    <topicref href="operations/UAN_Ansible_Roles.md" format="markdown"/>
 </map>


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3189. This will also make CASMUSER-3188 easier.

##### Issue Type

- Docs Pull Request

Simplifies the structure of both UAN guides and changes both to better match the organization of the Hugo-generated docs.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this by building HTML5 output on my local system. DITA-OT reported no errors after I updated the xref targets in my second commit.
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Very low risk to tarball and HPESC publishing pipelines.
