### PR TITLE
Update bootprep and config overview

### DIFF
--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -4,9 +4,7 @@
 
 Configuration of UAN nodes is performed by the Configuration Framework Service \(CFS\). CFS can apply configuration to both images and nodes. When the configuration is applied to nodes, the nodes must be booted and accessible through SSH over the Node Management Network \(NMN\).
 
-The preferred method of creating CFS configurations is to use the Shasta Admin Toolkit
-(SAT) `sat bootprep` command.  This command automates the creation of IMS images, CFS
-configurations, and BOS session templates. See [Create UAN Boot Images](Create_UAN_Boot_Images.md) for more details.
+The preferred method of creating CFS configurations is to use the Shasta Admin Toolkit (SAT) `sat bootprep` command.  This command automates the creation of IMS images, CFS configurations, and BOS session templates. See [Create UAN Boot Images](Create_UAN_Boot_Images.md) for more details.
 
 CFS uses configuration layers. Configuration layers allow the sharing of Ansible roles provided by other products, and by the site.  Non-root user access may be blocked during node configuration by enabling the `uan-set-nologin` and `uan-unset-nologin` configuration
 layers shown in the example bootprep file below. The parameterized fields are defined in

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -4,7 +4,73 @@
 
 Configuration of UAN nodes is performed by the Configuration Framework Service \(CFS\). CFS can apply configuration to both images and nodes. When the configuration is applied to nodes, the nodes must be booted and accessible through SSH over the Node Management Network \(NMN\).
 
-The Ansible roles involved in UAN configuration are listed in the site.yml file in the uan-config-management git repository in VCS. Most of the roles that are specific to image configuration are required for the operation as a UAN and must not be removed from site.yml.
+The preferred method of creating CFS configurations is to use the Shasta Admin Toolkit
+(SAT) `sat bootprep` command.  This command automates the creation of IMS images, CFS
+configurations, and BOS session templates. See [Create UAN Boot Images](Create_UAN_Boot_Images.md) for more details.
+
+CFS uses configuration layers. Configuration layers allow the sharing of Ansible roles provided by other products, and by the site.  Non-root user access may be blocked during node configuration by enabling the `uan-set-nologin` and `uan-unset-nologin` configuration
+layers shown in the example bootprep file below. The parameterized fields are defined in
+a `products_vars.yml` file.
+
+**NOTE** The first three layers are required and must not be removed or reordered.
+The `cos-application-last` layer, is required and must be the last or second to last
+layer in the configuration if `uan-set-nologin` and `uan-unset-nologin` are active.
+
+```bash
+- name: "{{default.note}}uan-{{recipe.version}}{{default.suffix}}"
+  layers:
+  # The first three layers are required and must not be reordered.
+  - name: shs-{{default.network_type}}_install-{{slingshot_host_software.working_branch}}
+    playbook: shs_{{default.network_type}}_install.yml
+    product:
+      name: slingshot-host-software
+      version: "{{slingshot_host_software.version}}"
+      branch: "{{slingshot_host_software.working_branch}}"
+  - name: cos-application-{{cos.working_branch}}
+    playbook: cos-application.yml
+    product:
+      name: cos
+      version: "{{cos.version}}"
+      branch: "{{cos.working_branch}}"
+  - name: csm-packages-{{csm.version}}
+    playbook: csm_packages.yml
+    product:
+      name: csm
+      version: "{{csm.version}}"
+# Optional layer to prevent non-root logins during configuration
+#  - name: uan-set-nologin-{{uan.working_branch}}
+#    playbook: set_nologin.yml
+#    product:
+#      name: uan
+#      version: "{{uan.version}}"
+#      branch: "{{uan.working_branch}}"
+  - name: uan-{{uan.working_branch}}
+    playbook: site.yml
+    product:
+      name: uan
+      version: "{{uan.version}}"
+      branch: "{{uan.working_branch}}"
+
+### additional CFS layers here... 
+
+# cos-application-last is required to be the last or second to last layer
+# when uan-set-nologin and uan-unset-nologin layers are active.
+  - name: cos-application-last-{{cos.working_branch}}
+    playbook: cos-application-after.yml
+    product:
+      name: cos
+      version: "{{cos.version}}"
+      branch: "{{cos.working_branch}}"
+# Optional layer to allow non-root logins after configuration
+#  - name: uan-unset-nologin-{{uan.working_branch}}
+#    playbook: unset_nologin.yml
+#    product:
+#      name: uan
+#      version: "{{uan.version}}"
+#      branch: "{{uan.working_branch}}"
+```
+
+The Ansible roles involved in the UAN layer of the configuration are listed in the site.yml file in the uan-config-management git repository in VCS. Most of the roles that are specific to image configuration are required for the operation as a UAN and must not be removed from site.yml.
 
 The UAN-specific roles involved in post-boot UAN node configuration are:
 
@@ -15,29 +81,7 @@ The UAN-specific roles involved in post-boot UAN node configuration are:
   ***NOTE:*** If a UAN layer is used in the Compute node CFS configuration, the `uan_interfaces` role will configure the default route on Compute nodes to be on the HSN, if the BICAN System Default Route is set to `CHN`.
 - [`uan_motd`](uan_motd.md): this role Provides a default message of the day that can be customized by the administrator.
 - [`uan_ldap`](uan_ldap.md): this optional role configures the connection to LDAP servers. To disable this role, the administrator must set 'uan_ldap_setup:no' in the 'uan-config-management' VCS repository.
+- [`uan_hardening`](uan_hardening.md): This role configures site/customer-defined network
+security of UANs, for example, preventing ssh out of the UAN over the NMN to NCN nodes.
 
 The UAN roles in site.yml are required and must not be removed, with exception of `uan_ldap` if the site is using some other method of user authentication. The `uan_ldap` may also be skipped by setting the value of `uan_ldap_setup` to `no` in a `group_vars` or `host_vars` configuration file.
-
-## UAN network configuration
-
-The `uan_interfaces` role configures the interfaces on the UAN nodes in three phases:
-
-1. Setup and configure the NMN.
-    1. Gather information from the System Layout Service \(SLS\) for the NMN.
-    2. Populate `/etc/resolv.conf`.
-    3. Configure the first OCP port on an HPE server, or the first LOM port on a Gigabyte server, as the `nmn0` interface.
-2. Set up the CAN or CHN, if wanted
-    1. Gather information from SLS for the CAN or CHN.
-    2. Configure the route to the CAN or CHN gateway as the default one.
-    3. Implement the CAN or CHN.
-        1. CAN: Implement bonded pair
-            1. On HPE servers, use the second port of the 25Gb OCP card and a second 25Gb card.
-            2. On Gigabyte servers, use both ports of the 40Gb card.
-        2. CHN: Implement the CHN interface on the HSN
-3. Setup customer-defined networks
-
-See [Configure Interfaces on UANs](Configure_Interfaces_on_UANs.md) for detailed instructions.
-
-### UAN LDAP network requirements
-
-LDAP configuration requires either a CAN or another customer-provided network that can route to the LDAP servers. Both such networks route outside of the HPE Cray EX system. If a UAN only has the `nmn0` interface configured and active, the UAN cannot route outside of the system.

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -75,7 +75,6 @@ The UAN-specific roles involved in post-boot UAN node configuration are:
   ***NOTE:*** If a UAN layer is used in the Compute node CFS configuration, the `uan_interfaces` role will configure the default route on Compute nodes to be on the HSN, if the BICAN System Default Route is set to `CHN`.
 - [`uan_motd`](uan_motd.md): this role Provides a default message of the day that can be customized by the administrator.
 - [`uan_ldap`](uan_ldap.md): this optional role configures the connection to LDAP servers. To disable this role, the administrator must set 'uan_ldap_setup:no' in the 'uan-config-management' VCS repository.
-- [`uan_hardening`](uan_hardening.md): This role configures site/customer-defined network
-security of UANs, for example, preventing ssh out of the UAN over the NMN to NCN nodes.
+- [`uan_hardening`](uan_hardening.md): This role configures site/customer-defined network security of UANs, for example, preventing ssh out of the UAN over the NMN to NCN nodes.
 
 The UAN roles in site.yml are required and must not be removed, with exception of `uan_ldap` if the site is using some other method of user authentication. The `uan_ldap` may also be skipped by setting the value of `uan_ldap_setup` to `no` in a `group_vars` or `host_vars` configuration file.

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -12,8 +12,7 @@ CFS uses configuration layers. Configuration layers allow the sharing of Ansible
 layers shown in the example bootprep file below. The parameterized fields are defined in
 a `products_vars.yml` file.
 
-**NOTE** The first three layers are required and must not be removed or reordered.
-The `cos-application-last` layer, is required and must be the last or second to last
+**IMPORTANT** Do not remove or reorder the first three layers. The UAN product requires these layers and this specific order. Also, keep the required `cos-application-last` layer, is as the last or second to last
 layer in the configuration if `uan-set-nologin` and `uan-unset-nologin` are active.
 
 ```bash

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -6,12 +6,9 @@ Configuration of UAN nodes is performed by the Configuration Framework Service \
 
 The preferred method of creating CFS configurations is to use the Shasta Admin Toolkit (SAT) `sat bootprep` command.  This command automates the creation of IMS images, CFS configurations, and BOS session templates. See [Create UAN Boot Images](Create_UAN_Boot_Images.md) for more details.
 
-CFS uses configuration layers. Configuration layers allow the sharing of Ansible roles provided by other products, and by the site.  Non-root user access may be blocked during node configuration by enabling the `uan-set-nologin` and `uan-unset-nologin` configuration
-layers shown in the example bootprep file below. The parameterized fields are defined in
-a `products_vars.yml` file.
+CFS uses configuration layers. Configuration layers allow the sharing of Ansible roles provided by other products, and by the site.  Non-root user access may be blocked during node configuration by enabling the `uan-set-nologin` and `uan-unset-nologin` configuration layers shown in the example bootprep file below. The parameterized fields are defined in a `products_vars.yml` file.
 
-**IMPORTANT** Do not remove or reorder the first three layers. The UAN product requires these layers and this specific order. Also, keep the required `cos-application-last` layer, is as the last or second to last
-layer in the configuration if `uan-set-nologin` and `uan-unset-nologin` are active.
+**IMPORTANT** Do not remove or reorder the first three layers. The UAN product requires these layers and this specific order. Also, keep the required `cos-application-last` layer, is as the last or second to last layer in the configuration if `uan-set-nologin` and `uan-unset-nologin` are active.
 
 ```bash
 - name: "{{default.note}}uan-{{recipe.version}}{{default.suffix}}"

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -191,6 +191,12 @@ configurations:
     product:
       name: csm
       version: 1.4
+  - name: uan-set-nologin
+    playbook: set_nologin.yml
+    product:
+      name: uan
+      version: 2.6.0
+      branch: integration-PRODUCT_VERSION
   - name: uan
     playbook: site.yml
     product:
@@ -202,6 +208,12 @@ configurations:
 
   - name: uan-rebuild-initrd
     playbook: rebuild-initrd.yml
+    product:
+      name: uan
+      version: 2.6.0
+      branch: integration-PRODUCT_VERSION
+  - name: uan-unset-nologin
+    playbook: unset_nologin.yml
     product:
       name: uan
       version: 2.6.0


### PR DESCRIPTION
#### Summary and Scope
This PR updates the UAN configuration overview to include the set/unset nologin layers in the UAN bootprep file.  Move the initial mention of using sat bootprep to the basic config page since that's what we want users to use.

Also removed some redundant info from the overview page.