### PR TITLE
adds incremented suffix to collection ID.

### DIFF
--- a/docs/portal/developer-portal/admin_publication.json
+++ b/docs/portal/developer-portal/admin_publication.json
@@ -10,7 +10,7 @@
 "lifecycle": "DRAFT",
 "products": ["1013083813"],
 "product_version": "UAN 2.6.0",
-"col_id": "crs8033",
+"col_id": "crs8033_@docid_suffix@",
 "full_title": "HPE Cray User Access Node (UAN) Software Administration Guide (S-8033)",
 "description": "This publication describes how to manage, configure, and troubleshoot User Access Nodes (UANs).",
 "creation_date": "2022-03-29T12:00:00",

--- a/docs/portal/developer-portal/install_publication.json
+++ b/docs/portal/developer-portal/install_publication.json
@@ -10,7 +10,7 @@
 "lifecycle": "DRAFT",
 "products": ["1013083813"],
 "product_version": "UAN 2.6.0",
-"col_id": "crs8032",
+"col_id": "crs8032_@docid_suffix@",
 "full_title": "HPE Cray User Access Node (UAN) Software Installation Guide (S-8032)",
 "description": "This publication describes how to install and upgrade UAN product software.",
 "creation_date": "2022-03-29T12:00:00",

--- a/vars.sh
+++ b/vars.sh
@@ -32,7 +32,7 @@ MINOR=`./vendor/semver get minor ${VERSION}`
 PATCH=`./vendor/semver get patch ${VERSION}`
 
 # This is the docID suffix that must be incremented with each public CSM recipe release
-DOCID_SUFFIX=4
+DOCID_SUFFIX=5
 
 # Versions for doc product manifest
 DOC_PRODUCT_MANIFEST_VERSION="^0.1.0" # Keep this field like this until further notice


### PR DESCRIPTION
#### Summary and Scope

- Fixes CASMUSER-3192

This does not need to go into this month's CSM recipe release. In fact, it **shouldn't** go into this release because I incremented the DOC_ID suffix variable for the next recipe release.

##### Issue Type

- Docs Tooling Pull Request

This change gives each release version of each UAN publication a unique "collection ID". HPESC views all docIDs that share the same collection ID as translations of the same document. 

This change allows us apply separate metadata to the UAN docs for a particular release. For example, publishing the UAN docs for an upcoming CSM recipe release as "confidential" (HPE viewable only) to HPESC when the official release day isn't known yet. 

See MTS-3267 for more details.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this by building and uploading to HPESC on my local system, followed by setting the test publication to "Confidential" and confirming that the other UAN docs were still publicly available. 
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
No known risk. The Hugo docs build process doesn't use this HPESC-specific metadata. Nor does the tarball build code.
