### PR TITLE
CASMUSER-3233: Update docs for uan_gpg_keys and uan_ca_cert roles

### DIFF
--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -172,7 +172,7 @@
     "dir": "operations",
     "weight": 90,
     "toc": [
-      "csm_gpg_keys.md",
+      "uan_gpg_keys.md",
       "uan_ca_cert.md",
       "uan_disk_config.md",
       "uan_hardening.md",
@@ -184,7 +184,7 @@
     ]
   },
   {
-    "title": "csm_gpg_keys",
+    "title": "uan_gpg_keys",
     "weight": 91
   },
   {

--- a/docs/portal/developer-portal/operations/csm_gpg_keys.md
+++ b/docs/portal/developer-portal/operations/csm_gpg_keys.md
@@ -1,3 +1,0 @@
-# `csm.gpg_keys`
-
-The `csm.gpg_keys` role fetches the required GPG keys needed for HPE RPM verification.

--- a/docs/portal/developer-portal/operations/uan_ca_cert.md
+++ b/docs/portal/developer-portal/operations/uan_ca_cert.md
@@ -1,3 +1,24 @@
 # `uan_ca_cert`
 
-The `uan_ca_cert` role installs a CA certificate on the system.
+The `uan_ca_cert` role installs a CA certificate onto the system.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+None.
+
+## Dependencies
+
+None.
+### Example Playbook
+
+```yaml
+- hosts: Application
+  roles:
+     - role: uan_ca_cert
+```
+
+This role is included in the UAN `site.yml` play.

--- a/docs/portal/developer-portal/operations/uan_gpg_keys.md
+++ b/docs/portal/developer-portal/operations/uan_gpg_keys.md
@@ -1,0 +1,59 @@
+# `uan_gpg_keys`
+
+The `uan_gpg_keys` role installs the CSM GPG signing public key. This role is a dependency of the
+`uan_packages` role.
+
+## Requirements
+
+The Kubernetes secret must be available in the namespace and field specified
+by the `uan_gpg_key_*` variables below. The key must be stored as a base64-encoded
+string.
+
+## Role Variables
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml`):
+
+`uan_gpg_key_k8s_secret`
+
+: The Kubernetes secret which contains the GPG public key.
+
+  Example:
+
+  ```yaml
+     uan_gpg_key_k8s_secret: "hpe-signing-key"
+  ```
+
+`uan_gpg_key_k8s_namespace`
+
+: The Kubernetes namespace which contains the secret.
+
+  Example:
+
+  ```yaml
+     uan_gpg_key_k8s_namespace: "services"
+  ```
+
+`uan_gpg_key_k8s_field`
+
+: The field in the Kubernetes secret that holds the GPG public key.
+
+  Example:
+
+  ```yaml
+     uan_gpg_key_k8s_field: "gpg-pubkey"
+  ```
+
+## Dependencies
+
+None.
+
+### Example Playbook
+
+```yaml
+   - hosts: Application
+      roles:
+         - role: uan_gpg_key
+```
+
+This role is included in the UAN `site.yml` play.

--- a/docs/portal/developer-portal/uan_admin_guide.ditamap
+++ b/docs/portal/developer-portal/uan_admin_guide.ditamap
@@ -20,7 +20,7 @@
         <topicmeta>
             <navtitle>UAN Ansible Roles</navtitle>
         </topicmeta>
-        <topicref href="operations/csm_gpg_keys.md" format="markdown"/>
+        <topicref href="operations/uan_gpg_keys.md" format="markdown"/>
         <topicref href="operations/uan_ca_cert.md" format="markdown"/>
         <topicref href="operations/uan_disk_config.md" format="markdown"/>
         <topicref href="operations/uan_hardening.md" format="markdown"/>

--- a/docs/portal/developer-portal/uan_install_guide.ditamap
+++ b/docs/portal/developer-portal/uan_install_guide.ditamap
@@ -23,7 +23,7 @@
         <topicmeta>
             <navtitle>UAN Ansible Roles</navtitle>
         </topicmeta>
-        <topicref href="operations/csm_gpg_keys.md" format="markdown"/>
+        <topicref href="operations/uan_gpg_keys.md" format="markdown"/>
         <topicref href="operations/uan_ca_cert.md" format="markdown"/>
         <topicref href="operations/uan_disk_config.md" format="markdown"/>
         <topicref href="operations/uan_hardening.md" format="markdown"/>


### PR DESCRIPTION
#### Summary and Scope

This PR updates the documentation for the uan_gpg_keys and uan_ca_cert roles.  It also renames the file csm_gpg_keys.md to uan_gpg_keys.md to match the actual role name.

It resolves CASMUSER-3233.

After merging to main, this PR should be cherry-picked to release/uan-2.6.