### PR TITLE
Add information on setting up HSM Node Groups for K3s

### DIFF
--- a/docs/portal/developer-portal/advanced/Designating_Application_Nodes_for_K3s.md
+++ b/docs/portal/developer-portal/advanced/Designating_Application_Nodes_for_K3s.md
@@ -1,0 +1,84 @@
+# Designating Application Nodes for K3s (Technical Preview)
+
+**WARNING**: This feature is currently a Technical Preview. Future releases will streamline these manual configuration steps. Therefore, some of these configuration options may change in future releases.
+
+## Overview
+
+Before K3s can be enabled to support UAIs on Application nodes, the Application nodes must be grouped in HSM as either `k3s_server` or `k3s_agent` nodes. The UAN Ansible K3s playbook uses these groups to determine what role they will have. Nodes grouped as `k3s_server` will become K3s control-plane (master) nodes, while nodes grouped as `k3s_agent` will become K3s agent (worker) nodes.
+
+**INFO:** For more information on how CFS uses HSM node groups to create Ansible host groups, see the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm). Follow the links to thet `Cray System Management Administration Guide->Configuration Management->Ansible Inventory->Dynamic inventory and host groups` section.
+
+When UAN software is installed or upgraded using IUF and these HSM node groups do not exist or have no members, one `Application_UAN` node type will be placed in the `k3s_server` group and the remaining nodes will be placed in the `k3s_agent` group.  If these groups exist and are not empty, IUF will not change them.
+
+This document provides procedures to manually change the membership of the `k3s_server` and `k3s_agent` HSM node groups.
+
+## Procedures
+
+### Getting a List of all Application_UAN Nodes 
+
+This command gathers all nodes with the `Application` role and `UAN` subrole from HSM. The output is sorted by XNAME.
+
+```bash
+$ cray hsm state components list \
+--role Application --subrole UAN \
+--format json | jq -r '.Components[].ID' \
+| sort
+   ```
+
+### Getting the Members of a HSM Node Group
+
+This command displays the members of a given HSM Node Group. Substitute either `k3s_server` or `k3s_agent` for `GROUP_NAME` .
+
+```bash
+$ cray hsm groups members list $GROUP_NAME
+```
+
+### Creating the HSM Node Group
+
+If the HSM Node Group doesn't exist, the `cray hsm groups create` command can create it. The following two examples show how group members may be provided as a comma-separated string of XNAMEs on the command line, or listed in a file.
+
+**NOTE:** HSM Node Groups used for K3s must be exclusive.  That is, a given node may be in either the `k3s_server` or `k3s_agent` group, not both. HSM provides the `exclusive-group` element to enforce this policy.  By having the `k3s_server` and `k3s_agent` groups have the same `k3s` `exclusive-group`, nodes are prevented from being members of both.
+
+This example creates the `k3s_server` group listing members on the command line.
+
+ ```bash
+ $ cray hsm groups create \
+ --members-ids "XNAME1,XNAME2,..." \
+ --exclusive-group "K3s" \
+ --description "K3s Control-Plane Nodes"\
+ --label "k3s_server"
+ ```
+
+This example creates the `k3s_agent` group using members in a text file.
+
+ ```bash
+ $ cray hsm groups create \
+ --members-file /path-to-member-file \
+ --exclusive-group "K3s" \
+ --description "K3s Agent Nodes"\
+ --label "k3s_agent"
+   ```
+
+### Modifying the HSM Node Group
+
+The `cray hsm groups members create` and `cray hsm groups members delete` commands modify membership of an existing HSM Node Group. In these examples, `GROUP_NAME` would be either `k3s_server` or `k3s_agent`.
+
+#### Adding a Member
+
+```bash
+$ cray hsm groups members create --id XNAME $GROUP_NAME
+```
+
+#### Deleting a Member
+
+```bash
+$ cray hsm groups members delete XNAME $GROUP_NAME
+```
+
+### Deleting a HSM Node Group
+
+This command deletes the node group contained in `GROUP_NAME`.
+
+```bash
+$ cray hsm groups delete $GROUP_NAME
+```

--- a/docs/portal/developer-portal/advanced/Enabling_K3s.md
+++ b/docs/portal/developer-portal/advanced/Enabling_K3s.md
@@ -25,7 +25,7 @@ There are alternate configurations of podman that would allow for different work
 
 The following steps should be completed prior to configuring the UAN with K3s.
 
-1. Designate a UAN to operate as the K3s control-plane node.
+1. Designate a UAN to operate as the K3s control-plane node. See [Designating Application Nodes for K3s](Designating_Application_Nodes_for_K3s.md).
 
    **Note**: In a future release, additional UANs will be able to join as extra manager or worker nodes. 
 

--- a/docs/portal/developer-portal/hugo_toc.json
+++ b/docs/portal/developer-portal/hugo_toc.json
@@ -98,6 +98,7 @@
         "Enabling_CAN_CHN.md",
         "Repurposing_Compute_as_UAN.md",
         "SLES_Image.md",
+        "Designating_Application_Nodes_for_K3s.md",
         "Enabling_K3s.md"
     ]
   },
@@ -118,8 +119,12 @@
     "weight": 54
   },
   {
-    "title": "Configuring a UAN for K3s (Technical Preview)",
+    "title": "Designating Application Nodes for K3s (Technical Preview)",
     "weight": 55
+  },
+  {
+    "title": "Configuring a UAN for K3s (Technical Preview)",
+    "weight": 56
   },
   {
     "title": "Upgrade",

--- a/docs/portal/developer-portal/uan_admin_guide.ditamap
+++ b/docs/portal/developer-portal/uan_admin_guide.ditamap
@@ -35,6 +35,7 @@
         <topicref href="advanced/Enabling_CAN_CHN.md" format="markdown"/>
         <topicref href="advanced/Repurposing_Compute_as_UAN.md" format="markdown"/>
         <topicref href="advanced/SLES_Image.md" format="markdown"/>
+        <topicref href="advanced/Designating_Application_Nodes_for_K3s.md" format="markdown"/>
         <topicref href="advanced/Enabling_K3s.md" format="markdown"/>
     </topichead>
     <topicref href="operations/Boot_UANs.md" format="markdown"/>


### PR DESCRIPTION
#### Summary and Scope
This PR adds documentation on adding UAN nodes to the necessary HSM node groups to support K3s configuration.