### PR TITLE
CASMUSER-3247

### DIFF
--- a/docs/portal/developer-portal/advanced/Designating_Application_Nodes_for_K3s.md
+++ b/docs/portal/developer-portal/advanced/Designating_Application_Nodes_for_K3s.md
@@ -1,14 +1,14 @@
 # Designating Application Nodes for K3s (Technical Preview)
 
-**WARNING**: This feature is currently a Technical Preview. Future releases will streamline these manual configuration steps. Therefore, some of these configuration options may change in future releases.
+**WARNING**: This feature is a Technical Preview. Future releases will streamline these manual configuration steps. Therefore, some of these configuration options may change in future releases.
 
 ## Overview
 
 Before K3s can be enabled to support UAIs on Application nodes, the Application nodes must be grouped in HSM as either `k3s_server` or `k3s_agent` nodes. The UAN Ansible K3s playbook uses these groups to determine what role they will have. Nodes grouped as `k3s_server` will become K3s control-plane (master) nodes, while nodes grouped as `k3s_agent` will become K3s agent (worker) nodes.
 
-**INFO:** For more information on how CFS uses HSM node groups to create Ansible host groups, see the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm). Follow the links to thet `Cray System Management Administration Guide->Configuration Management->Ansible Inventory->Dynamic inventory and host groups` section.
+**INFO:** For more information on how CFS uses HSM node groups to create Ansible host groups, see the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm). Follow the links to the `Cray System Management Administration Guide->Configuration Management->Ansible Inventory->Dynamic inventory and host groups` section.
 
-When UAN software is installed or upgraded using IUF and these HSM node groups do not exist or have no members, one `Application_UAN` node type will be placed in the `k3s_server` group and the remaining nodes will be placed in the `k3s_agent` group.  If these groups exist and are not empty, IUF will not change them.
+When UAN software is installed or upgraded using IUF, and these HSM node groups do not exist or have no members, one `Application_UAN` node type will be placed in the `k3s_server` group. The remaining nodes will be placed in the `k3s_agent` group. If these groups exist and are not empty, IUF will not change them.
 
 This document provides procedures to manually change the membership of the `k3s_server` and `k3s_agent` HSM node groups.
 
@@ -25,9 +25,9 @@ $ cray hsm state components list \
 | sort
    ```
 
-### Getting the Members of a HSM Node Group
+### Getting the Members of an HSM Node Group
 
-This command displays the members of a given HSM Node Group. Substitute either `k3s_server` or `k3s_agent` for `GROUP_NAME` .
+This command returns the members of a given HSM Node Group. Substitute either `k3s_server` or `k3s_agent` for `GROUP_NAME`.
 
 ```bash
 $ cray hsm groups members list $GROUP_NAME
@@ -35,9 +35,9 @@ $ cray hsm groups members list $GROUP_NAME
 
 ### Creating the HSM Node Group
 
-If the HSM Node Group doesn't exist, the `cray hsm groups create` command can create it. The following two examples show how group members may be provided as a comma-separated string of XNAMEs on the command line, or listed in a file.
+If the HSM Node Group does not exist, the `cray hsm groups create` command can create it. The following two examples show how group members may be provided as a comma-separated string of XNAMEs on the command line, or listed in a file.
 
-**NOTE:** HSM Node Groups used for K3s must be exclusive.  That is, a given node may be in either the `k3s_server` or `k3s_agent` group, not both. HSM provides the `exclusive-group` element to enforce this policy.  By having the `k3s_server` and `k3s_agent` groups have the same `k3s` `exclusive-group`, nodes are prevented from being members of both.
+**NOTE:** HSM Node Groups used for K3s must be exclusive. That is, a given node may be in either the `k3s_server` or `k3s_agent` group, not both. HSM provides the `exclusive-group` element to enforce this policy. By having the `k3s_server` and `k3s_agent` groups have the same `k3s` `exclusive-group`, nodes are prevented from being members of both.
 
 This example creates the `k3s_server` group listing members on the command line.
 
@@ -75,7 +75,7 @@ $ cray hsm groups members create --id XNAME $GROUP_NAME
 $ cray hsm groups members delete XNAME $GROUP_NAME
 ```
 
-### Deleting a HSM Node Group
+### Deleting an HSM Node Group
 
 This command deletes the node group contained in `GROUP_NAME`.
 

--- a/docs/portal/developer-portal/advanced/Enabling_CAN_CHN.md
+++ b/docs/portal/developer-portal/advanced/Enabling_CAN_CHN.md
@@ -1,6 +1,6 @@
 # Enabling the Customer Access Network (CAN) or the Customer High Speed Network (CHN)
 
-The UAN product provides a role, `uan_interfaces` in the Configuration Framework Service (CFS). This role is suitable for Application type nodes, and in some circumstances, configuring the CHN, on Compute type nodes.
+The UAN product provides a role, `uan_interfaces` in the Configuration Framework Service (CFS). This role is suitable for Application type nodes, and in some circumstances, configuring the CHN on Compute type nodes.
 
 1. Enable CAN or CHN by setting the following in the UAN CFS repo (the filename may be modified to whatever is appropriate):
 
@@ -9,20 +9,20 @@ The UAN product provides a role, `uan_interfaces` in the Configuration Framework
     uan_can_setup: true
     ```
     
-1. SLS will be configured with either CAN or CHN, `uan_interfaces` will use this setting to determine if a default route should be established over the nmn (CAN) or the hsn (CHN). To see how the site is configured, query SLS:
+1. SLS will be configured with either CAN or CHN, `uan_interfaces` will use this setting to determine if a default route will be established over the NMN (CAN) or the HSN (CHN). To see how the site is configured, query SLS:
 
    ```bash
    ncn-m001:~/ $ cray sls search networks list --name CHN --format json | jq -r '.[] | .Name'
    CHN
    ```
 
-1. (Optional) If the compute nodes are going to use the UAN CFS role `uan_interfaces` to set a default route on the CHN, make sure there is an appropriate ansible setting for the compute nodes in addition to the UANs:
+1. (Optional) If the compute nodes are going to use the UAN CFS role `uan_interfaces` to set a default route on the CHN, make sure that there is an appropriate ansible setting for the compute nodes and the UANs:
 
     ```bash
     ncn-m001:~/ $ cat group_vars/Compute/can.yml
     uan_can_setup: true
     ```
 
-1. Once `uan_can_setup` has been enabled, update the CFS configuration used for the nodes to initiate a reconfiguration (see the Configuration Management section of the CSM documentation for more information).
+1. After `uan_can_setup` has been enabled, update the CFS configuration used for the nodes to initiate a reconfiguration (see the Configuration Management section of the CSM documentation for more information).
 
 1. The CSM documentation provides additional resources to validate the configuration of CAN and CHN for UANs and Computes. Consult the section titled "Enabling Customer High Speed Network Routing" in the CSM documentation for more information.

--- a/docs/portal/developer-portal/advanced/Enabling_K3s.md
+++ b/docs/portal/developer-portal/advanced/Enabling_K3s.md
@@ -114,7 +114,7 @@ The following Nexus group repository is created and references the previous UAN 
 
 - uan-2.6-third-party
 
-This repository will contain the installer for K3s, Helm charts for HAProxy and MetalLB, and so on
+This repository will contain the installer for K3s, Helm charts for HAProxy and MetalLB, and so on.
 
 ### Validation Tests 
 

--- a/docs/portal/developer-portal/advanced/Repurposing_Compute_as_UAN.md
+++ b/docs/portal/developer-portal/advanced/Repurposing_Compute_as_UAN.md
@@ -1,16 +1,16 @@
 # Repurposing a Compute Node as a UAN
 
-This section describes how to repurpose a compute node to be used as a User Access Node (UAN).  This is typically done when the processor type of the compute node is not yet available in a UAN server.
+This section describes how to repurpose a compute node to be used as a User Access Node (UAN). This reconfiguration is typically done when the processor type of the compute node is not yet available in a UAN server.
 
 ## Overview
 
 The following steps outline the process of repurposing a compute node to be used as a UAN.
 
-  1. Verify the System Default Route is set to `CHN`.
+  1. Verify that the System Default Route is set to `CHN`.
     
-  1. Change the role of the compute node in the Hardware State Manager from `Compute` to `Application` and set the sub-role to `UAN`.
+  1. Change the role of the compute node in the Hardware State Manager from `Compute` to `Application` and set the subrole to `UAN`.
 
-  1. Ensure that IPs on the CHN exist for the computes nodes in SLS.
+  1. Ensure that IP addresses on the CHN exist for the compute nodes in SLS.
 
   1. Boot the repurposed compute node as a UAN.
 
@@ -18,7 +18,7 @@ The following steps outline the process of repurposing a compute node to be used
 
 ## Prerequisites
 
-There are no changes needed in hardware, network cabling, or UEFI/BIOS/BMC configuration to repurpose a compute node for use as a UAN.  However, compute nodes do not have the necessary network interface cards to support user access over the Customer Access Network (CAN). Additionally, the network configuration of Mountain Cabinets do not support the CAN network. Therefore, repurposing a compute node as a UAN requires the system to be configured to use the Customer High-Speed Network (CHN) and that the compute nodes have a CHN IP address in SLS.
+There are no changes needed in hardware, network cabling, or UEFI/BIOS/BMC configuration to repurpose a compute node for use as a UAN. However, compute nodes do not have the necessary NICs to support user access over the Customer Access Network (CAN). Additionally, the network configuration of Mountain Cabinets does not support the CAN network. Therefore, repurposing a compute node as a UAN requires the system to be configured to use the Customer High-Speed Network (CHN). The compute nodes must also have a CHN IP address in SLS.
 
 * The SLS Networks setting for the `SystemDefaultRoute` must be `CHN`
 * The repurposed compute nodes must have CHN IP addresses in SLS
@@ -30,33 +30,33 @@ Perform the following steps to repurpose a compute node for use as a UAN.
 
 1. Log in to the master node `ncn-m001`. All commands in this procedure are run from the master node.
 
-1. Verify the system is configured to use the `CHN` as the System Default Route. If the `SystemDefaultRoute` is not `CHN`, the compute nodes may not be repurposed as UAN.
+1. Verify that the system is configured to use the `CHN` as the System Default Route. If the `SystemDefaultRoute` is not `CHN`, the compute nodes may not be repurposed as UAN.
 
     ```bash
     ncn-m001# cray sls networks describe BICAN  --format json | jq -r '.ExtraProperties.SystemDefaultRoute'
     ```
 
-1. Verify a CHN IP address exists in SLS for each repurposed compute node. Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node. The compute node must have a CHN IP address in SLS or it cannot be repurposed as a UAN.  See `Add Compute IP addresses to CHN SLS data` section of the Cray System Management documentation for information on adding compute nodes to the CHN.
+1. Verify that a CHN IP address exists in SLS for each repurposed compute node. Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node. The compute node must have a CHN IP address in SLS or it cannot be repurposed as a UAN. See `Add Compute IP addresses to CHN SLS data` section of the Cray System Management documentation for information on adding compute nodes to the CHN.
 
     ```bash
     ncn-m001# cray sls networks describe CHN | q -r '.ExtraProperties.Subnets[] | select(.FullName == "CHN Bootstrap DHCP Subnet") | .IPReservations[] | select(.Comment == "<XNAME>")'
     ```
 
-1. Verify that `uan_can_setup: true` is set in the `uan-config-management` CFS repo.  See [Enabling the Customer Access Network (CAN) or the Customer High Speed Network (CHN)](../advanced/Enabling_CAN_CHN.md) for more information.
+1. Verify that `uan_can_setup: true` is set in the `uan-config-management` CFS repo. See [Enabling the Customer Access Network (CAN) or the Customer High Speed Network (CHN)](../advanced/Enabling_CAN_CHN.md) for more information.
 
-1. Change the role and sub-role in HSM of the compute node(s) being repurposed as UANs to `Application` and `UAN`, respectively.  Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node.
+1. Change the role and subrole in HSM of the compute node or nodes being repurposed as UANs to `Application` and `UAN`, respectively. Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node.
 
     ```bash
     ncn-m001# cray hsm state components role update --role Application --sub-role UAN <XNAME>
     ```
 
-1. Verify the role and sub-role in HSM of the repurposed compute node(s) has been changed to 'Application` and 'UAN`, respectively.  Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node.
+1. Verify the role and subrole in HSM of the repurposed compute node or nodes have been changed to 'Application` and 'UAN`, respectively. Repeat the following command and replace `<XNAME>` with the xname of each repurposed compute node.
 
     ```bash
     ncn-m001# cray hsm state components describe <XNAME>
     ```
 
-1. Run the BOS session template used to boot the UAN nodes. See [Boot UAN Nodes](../operations/Boot_UANs.md) for more information on booting UAN nodes with BOS.  Replace `<UAN_SESSIONTEMPLATE>` with the name of the BOS session template used to boot the UAN nodes and `<XNAME>` with the xname of the repurposed compute node.
+1. Run the BOS session template used to boot the UAN nodes. See [Boot UAN Nodes](../operations/Boot_UANs.md) for more information on booting UAN nodes with BOS. Replace `<UAN_SESSIONTEMPLATE>` with the name of the BOS session template used to boot the UAN nodes and `<XNAME>` with the xname of the repurposed compute node.
 
     ```bash
     ncn-m001# cray bos session create --template-uuid <UAN_SESSIONTEMPLATE> --operation reboot --limit <XNAME>
@@ -64,11 +64,11 @@ Perform the following steps to repurpose a compute node for use as a UAN.
 
 ## Verification as a UAN
 
-Once the repurposed compute node is booted as a UAN, the following steps will verify it is configured as a UAN. These steps may vary dependent upon how the site has configured the UAN nodes.
+After the repurposed compute node is booted as a UAN, the following steps will verify it is configured as a UAN. These steps may vary dependent upon how the site has configured the UAN nodes.
 
 ### Basic UAN Configuration Checks
 
-1. Verify the repurposed compute node has finished the configuration phase. The output should display "configured".
+1. Verify that the repurposed compute node has finished the configuration phase. This command must return `configured`.
 
     ```bash
     ncn-m001# cray cfs components describe <XNAME> --format json | jq -r .configurationStatus
@@ -82,7 +82,7 @@ Once the repurposed compute node is booted as a UAN, the following steps will ve
     uan# ip a | grep hsn0
     ```
 
-1. Verify the default route is via `hsn0`
+1. Verify that the default route is through `hsn0`
 
    ```bash
    uan# ip r | grep default
@@ -92,24 +92,24 @@ Once the repurposed compute node is booted as a UAN, the following steps will ve
 
 ### Common UAN Configuration Checks
 
-1. If LDAP is used for user authentication, verify the LDAP service is reachable.
+1. If LDAP is used for user authentication, verify that the LDAP service is reachable.
 
     ```bash
     uan# ping <ldap_service_ip>
     ```
 
-1. If SLURM is used, test `sinfo` and `srun` commands.  This example `srun` command should return the hostname of 4 compute nodes.
+1. If Slurm is used, test `sinfo` and `srun` commands. This example `srun` command should return the hostname of four compute nodes.
 
     ```bash
     uan# sinfo
 
     uan# srun -N4 hostname
     ```
-### Verify Users can Login
+### Verify that Users can Login
 
 1. Login to the repurposed compute node as an authorized non-root user from any host that should have UAN access.
 
-1. If SLURM is used, test `sinfo` and `srun` commands.  This example `srun` command should return the hostname of 4 compute nodes.
+1. If Slurm is used, test `sinfo` and `srun` commands. This example `srun` command should return the hostname of four compute nodes.
 
     ```bash
     uan# sinfo

--- a/docs/portal/developer-portal/advanced/SLES_Image.md
+++ b/docs/portal/developer-portal/advanced/SLES_Image.md
@@ -1,16 +1,16 @@
 # Booting an Application Node with a SLE HPC Image (Technical Preview)
 
-A SLE HPC image is available for use with Application Node types such as gateways and LNet routers. This image is currently considered a "Technical Preview" as the initial support for booting with SLE HPC Images without COS. This Application Node image differs from the standard COS-based image because this image does not include the COS kernel and libraries that Compute Nodes (CNs) have.
+A SLE HPC image is available for use with Application Node types such as gateways and LNet routers. This image is considered a "Technical Preview" as the initial support for booting with SLE HPC Images without COS. This Application Node image differs from the standard COS-based image because this image does not include the COS kernel and libraries that Compute Nodes (CNs) have.
 
-The image is built from the same pipeline as Non-Compute Node (NCN) Images. Similarties may be noticed including the kernel and package versions.
+The image is built from the same pipeline as Non-Compute Node (NCN) Images. Similarities may be noticed including the kernel and package versions.
 
 This procedure documents how to boot and configure this image.
 
 ## Limitations
 
-As this is currently a "Technical Preview" of supporting SLE HPC Images on Application Nodes, there are several limitations:
+As this feature is a "Technical Preview" of supporting SLE HPC Images on Application Nodes, there are several limitations:
 
-* S3 presigned URLs with an expiration limit for the rootfs must be created.
+* S3 presigned URLs with an expiration limit for the `rootfs` must be created.
 * BSS parameters must be set with `cray bss bootparameters replace ...`
 * BOS Sessions and Templates are not supported.
 * CFS Configurations that operate on COS and NCN images are not yet supported.
@@ -36,7 +36,7 @@ Perform the following steps to configure and boot a SLE HPC image on an Applicat
 
 1. Log in to the master node `ncn-m001`. All commands in this procedure are run from the master node.
 
-1. Verify the UAN release contains a SLES image.
+1. Verify that the UAN release contains a SLES image.
 
     ```bash
     ncn-m001# UAN_RELEASE=2.5
@@ -61,7 +61,7 @@ Perform the following steps to configure and boot a SLE HPC image on an Applicat
     }
     ```
 
-1. Customize the image using SAT Bootprep. This will add a root password to the image as one is not included. If CFS is not going to be used on this node, this step is optional. Support for additional product layers will be added in subsequent releases.
+1. Customize the image using SAT Bootprep. These commands will add a root password to the image as one is not included. If CFS is not going to be used on this node, this step is optional. Support for additional product layers will be added in subsequent releases.
 
     ```bash
     ncn-m001# cat bootprep-sles-uan.yml
@@ -101,7 +101,7 @@ Perform the following steps to configure and boot a SLE HPC image on an Applicat
     }
     ```
 
-1. Create a presigned URL for the rootfs. This is needed for the node to boot in this release, in the future, this will be integrated into BSS and will not need to be performed. This URL will be valid for 1 hour and will need to be recreated if the node reboots after the URL expires. To set a longer expiration, adjust the "aws s3 presign" command accordingly.
+1. Create a presigned URL for the `rootfs`. This step is needed for the node to boot in this release, in the future, this step will be integrated into BSS and will not need to be performed. This URL will be valid for 1 hour and must be recreated if the node reboots after the URL expires. To set a longer expiration, adjust the `aws s3 presign` command accordingly.
 
     ```base
     ncn-m001# export AWS_ACCESS_KEY_ID=`kubectl get secrets -o yaml ims-s3-credentials -ojsonpath='{.data.access_key}' | base64 -d`
@@ -128,7 +128,7 @@ Perform the following steps to configure and boot a SLE HPC image on an Applicat
     ncn-m001:~ # MAC=b4:2e:99:fd:45:c8
     ```
 
-1. Update BSS with the kernel, initrd, and desired parameters. 
+1. Update BSS with the kernel, initrd, and wanted parameters. 
 
     ```bash
     ncn-m001:~ # PARAMS="ifname=nmn0:$MAC ip=nmn0:dhcp spire_join_token=\${SPIRE_JOIN_TOKEN} biosdevname=1 pcie_ports=native transparent_hugepage=never console=tty0 console=ttyS0,115200 iommu=pt metal.no-wipe=1 initrd=initrd root=live:$ROOTFS_URL rd.live.ram=0 rd.writable.fsimg=0 rd.skipfsck rd.live.squashimg=filesystem.squashfs rd.live.overlay.thin=1 rd.live.overlay.overlayfs=1 rd.luks=0 rd.luks.crypttab=0 rd.lvm.conf=0 rd.lvm=1 rd.auto=1 rd.md=1 rd.dm=0 rd.neednet=0 rd.peerdns=1 rd.md.waitclean=1 rd.multipath=0 rd.md.conf=1 rd.bootif=0 hostname=$NODE rd.net.dhcp.retry=3 append nosplash quiet log_buf_len=1 rd.retry=10 rd.shell"
@@ -161,7 +161,7 @@ Perform the following steps to configure and boot a SLE HPC image on an Applicat
 
 ## Troubleshooting
 
-Some general troublshooting tips may help in getting started using the SLE HPC image.
+Some general troubleshooting tips may help in getting started using the SLE HPC image.
 
 ### Dracut failures during booting
 
@@ -198,7 +198,7 @@ Some general troublshooting tips may help in getting started using the SLE HPC i
     [   28.400096] dracut-initqueue[945]: Warning: Could not boot.
     ```
 
-1. The root filesystem doesn't won't download because the URL is too long. Regenerate the URL using the aws command.
+1. The root filesystem does not download because the URL is too long. Regenerate the URL using the `aws` command.
 
     ```bash
     2022-08-03 19:41:52   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to create the file
@@ -221,7 +221,7 @@ Some general troublshooting tips may help in getting started using the SLE HPC i
     [    9.807724] dracut-initqueue[1429]: Warning: Downloading 'http://rgw-vip/boot-images/13964414-bbad-40e9-9e31-a3683010febb/rootfs?AWSAccessKeyId=I43RBLH07R65TRO3AL02&Signature=7%2FgOCotleoyLPGmeyG%2FFX8tpkWg%3D&Expires=1661523713' failed!
     ```
 
-1. The dracut module livenet is missing from the initrd. Make sure the initrd was regenerated with `/srv/cray/scripts/common/create-ims-initrd.sh` if CFS was used.
+1. The dracut module `livenet` is missing from the initrd. Make sure that the initrd was regenerated with `/srv/cray/scripts/common/create-ims-initrd.sh` if CFS was used.
 
     ```bash
     2022-08-24 14:48:53 [    5.784023] dracut: FATAL: Don't know how to handle 'root=live:http://rgw-vip/boot-images/e88ed416-5d58-4421-9013-fa2171ac11b8/rootfs?AWSAccessKeyId=I43RBLH07R65TRO3AL02&Signature=bL661kZHPyEgBsLLEuJHFz3zKVs%3D&Expires=1661438587'
@@ -237,7 +237,7 @@ Some general troublshooting tips may help in getting started using the SLE HPC i
     ssh: connect to host uan01 port 22: No route to host
     ```
 
-1. Unable to log in to the node with a password. No root password is defined in the image by default, one must be added via CFS or by modifying the squashfs filesystem.
+1. Unable to log in to the node with a password. No root password is defined in the image by default, one must be added by CFS or by modifying the squashfs filesystem.
 
     ```bash
     ncn-m001:# ssh app01

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -2,9 +2,9 @@
 
 ## Install and Upgrade Framework
 
-The Install and Upgrade Framework (IUF) provides commands which install, upgrade and deploy products on systems managed by CSM. IUF capabilities are described in detail in the [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-14/). The initial install and upgrade workflows described in the [HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)](https://www.hpe.com/support/ex-S-8052) detail when and how to use IUF with a new release of UAN or any other HPE Cray EX product.
+The Install and Upgrade Framework (IUF) provides commands which install, upgrade, and deploy products on systems managed by CSM. IUF capabilities are described in detail in the [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-14/). The initial install and upgrade workflows described in the [HPE Cray EX System Software Stack Installation and Upgrade Guide for CSM (S-8052)](https://www.hpe.com/support/ex-S-8052) detail when and how to use IUF with a new release of UAN or any other HPE Cray EX product.
 
-This document **does not** replicate install, upgrade or deployment procedures detailed in the [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-14/). This document provides details regarding software and configuration content specific to UAN which may be needed when installing, upgrading or deploying a UAN release. The [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-14/) will indicate when sections of this document should be referred to for detailed information.
+This document **does not** replicate the install, upgrade, or deployment procedures detailed in the [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-14/). This document provides details regarding software and configuration content specific to UAN which may be needed when installing, upgrading, or deploying a UAN release. The [IUF section](https://cray-hpe.github.io/docs-csm/en-14/operations/iuf/iuf/) of the [Cray System Management Documentation](https://cray-hpe.github.io/docs-csm/en-14/) will indicate when sections of this document must be seen for detailed information.
 
 IUF will perform the following tasks for a release of UAN.
 
@@ -30,14 +30,14 @@ IUF uses a variety of CSM and SAT tools when performing these tasks. The [IUF se
 
 ### IUF Resource Files
 
-IUF uses the following files to drive the install/upgrade of UAN.  These are provided by the `hpc-csm-software-recipe` VCS repository.
+IUF uses the following files to drive the install or upgrade of UAN. These files are provided by the `hpc-csm-software-recipe` VCS repository.
 
 - `product_vars.yaml` (**Required**)
-  - Contains the list of products and versions to be installed together. It also contains the `working_branch` variables for the products.  This file is located in a directory under `/etc/cray/upgrade/csm/`. For example, `/etc/cray/upgrade/csm/admin`.
+  - Contains the list of products and versions to be installed together. It also contains the `working_branch` variables for the products. This file is in a directory under `/etc/cray/upgrade/csm/`. For example, `/etc/cray/upgrade/csm/admin`.
   - The path to this file is defined on the `iuf` command line using the IUF recipe vars (`-rv`) option.  For example, `-rv /etc/cray/upgrade/csm/admin`.
 - `site_vars.yaml` (**Required**)
   - This file allows the administrator to override values in `product_vars.yaml` and defines the site VCS branching strategy. It may be placed in any directory under `/etc/cray/upgrade/csm`.
-  - The path to this file is defined on the `iuf` command line using the IUF site vars (`-sv`) option.  For example, `-sv /etc/cray/upgrade/csm/admin/site_vars.yaml`.
+  - The path to this file is defined on the `iuf` command line using the IUF site vars (`-sv`) option. For example, `-sv /etc/cray/upgrade/csm/admin/site_vars.yaml`.
 - `compute-and-uan-bootprep.yaml` (**Required**)
   - This file is typically installed in the `/etc/cray/upgrade/csm/bootprep` directory and defines variables for the following tasks:
     - Create a compute node image which will be configured for use on UAN
@@ -47,30 +47,30 @@ IUF uses the following files to drive the install/upgrade of UAN.  These are pro
 
 ## IUF Stage Details for UAN
 
-This section describes any UAN details that an administrator may need to be aware of before executing IUF stages. Entries are prefixed with **Information** if no administrative action is required or **Action** if an administrator may need to perform tasks outside of IUF.
+This section describes any UAN details that an administrator must be aware of before executing IUF stages. Entries are prefixed with **Information** if no administrative action is required or **Action** if an administrator must perform tasks outside of IUF.
 
 ### process-media
 
-**Action**: Before executing this stage, the administrator should ensure the UAN product tarball is in a media directory under `/etc/cray/upgrade/csm/`.  When more than one product is being installed, place all the product tarballs in the same directory.
+**Action**: Before executing this stage, the administrator must ensure that the UAN product tar file is in a media directory under `/etc/cray/upgrade/csm/`. When more than one product is being installed, place all the product tar files in the same directory.
 
 ### update-vcs-config
 
-**Action**: Before executing this stage, the administrator should ensure the IUF site variables file (see `iuf -sv SITE_VARS`) is updated to reflect site preferences, including the desired VCS branching configuration. The branching configuration will be used by the `update-vcs-config` stage when modifying UAN branches in VCS.
+**Action**: Before executing this stage, the administrator must ensure the IUF site variables file (see `iuf -sv SITE_VARS`) is updated to reflect site preferences, including the wanted VCS branching configuration. The `update-vcs-config` stage will use the branching configuration when modifying UAN branches in VCS.
 
 ### update-cfs-config
 
-**Action**: Before executing this stage, any site-local UAN configuration changes should be made so the following stages execute using the desired UAN configuration values. See the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section of this documentation for UAN configuration content details. Note that the [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh install scenarios.
+**Action**: Before executing this stage, any site-local UAN configuration changes must be made so that the following stages execute using the wanted UAN configuration values. See the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section of this documentation for UAN configuration content details. The [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh installation scenarios.
 
 ## UAN Content Installed
 
-The following subsections describe the majority of the UAN content installed and configured on the system by IUF. The new version of UAN \(2.6.XX\) and its artifacts will be displayed in the CSM product catalog alongside any previously released version of UAN and its artifacts.
+The following subsections describe most of the UAN content installed and configured on the system by IUF. The new version of UAN \(2.6.XX\) and its artifacts will be displayed in the CSM product catalog alongside any previously released version of UAN and its artifacts.
 
 
 ### Configuration
 
-UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number \(2.6.XX\) to distinguish it from any previously released UAN configuration content. This content is described in detail in the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section.
+UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number. That release number, such as \(2.6.XX\) distinguishes it from any previously released UAN configuration content. This content is described in detail in the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section.
 
-For application nodes based on COS, the COS compute image is used as the base application node image and two COS CFS layers are required. The first COS CFS layer runs the `cos-application.yml` Ansible playbook and ensures that the COS content is applied as part of the image customization and node personalization processes. This COS CFS layer must precede the UAN CFS layer in the UAN CFS configuration. A second  COS CFS layer running the Ansible playbook, `cos-application-after.yml`, runs after the UAN CFS layer of the UAN CFS configuration to ensure that the application node initrd is rebuilt and that any customer defined filesystems are configured.
+For application nodes based on COS, the COS compute image is used as the base application node image and two COS CFS layers are required. The first COS CFS layer runs the `cos-application.yml` Ansible playbook and ensures that the COS content is applied as part of the image customization and node personalization processes. This COS CFS layer must precede the UAN CFS layer in the UAN CFS configuration. A second COS CFS layer running the Ansible playbook, `cos-application-after.yml`, runs after the UAN CFS layer of the UAN CFS configuration. This second COS CFS layer ensures that the application node initrd is rebuilt and that any customer-defined filesystems are configured.
 
 Input files for `sat bootprep` are provided in the `hpc-csm-software-recipe` VCS repository and include COS components in the CFS configuration, node image, and BOS session template definitions. The `compute-and-uan-bootprep.yaml` input file is used for compute and application nodes.
 
@@ -91,7 +91,7 @@ The following instructions describe how to set the root password for UAN/Applica
     ncn-m001# kubectl exec -itn vault cray-vault-0 -c vault -- sh
     ```
 
-1. Once attached to the pod's shell, log into vault and read the `secret/uan` key by executing the following commands. If the secret is empty, "No value found at secret/uan" will be displayed.
+1. After you are attached to the pod's shell, log into vault and read the `secret/uan` key by executing the following commands. If the secret is empty, "No value found at secret/uan" will be displayed.
 
     ```bash
     pod# export VAULT_ADDR=http://cray-vault:8200
@@ -107,13 +107,13 @@ The following instructions describe how to set the root password for UAN/Applica
       ncn-m001# openssl passwd -6 -salt $(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c4) PASSWORD
       ```
 
-    b.  Take the HASH value returned from the previous command and enter the following in the vault pod's shell. Instead of HASH, use the value returned from the previous step.  You must escape the HASH value with the single quote to preserve any special characters that are part of the HASH value. If you previously have exited the pod, repeat steps 1-3 above; there is no need to perform the vault read since the content is empty.
+    b.  Take the HASH value returned from the previous command and enter the following in the vault pod's shell. Instead of HASH, use the value returned from the previous step.  You must escape the HASH value with the single quote to preserve any special characters that are part of the HASH value. If you previously have exited the pod, repeat the previous Steps 1-3; there is no need to perform the vault read since the content is empty.
 
       ```bash
       pod# vault write secret/uan root_password='HASH'
       ```
 
-    c.  Verify the new hash value is stored.
+    c.  Verify that the new hash value is stored.
 
       ```bash
       pod# vault read secret/uan
@@ -121,9 +121,23 @@ The following instructions describe how to set the root password for UAN/Applica
       pod# exit
       ```
 
+1. **Optional** Write any uan_ldap sensitive data, such as the `ldap_default_authtok` value, to the HashiCorp Vault.
+
+    The vault login command will request a token. That token value is the output of the Step 1. The vault `read secret/uan_ldap` command verifies that the `uan_ldap` data was stored correctly. Any values stored here will be written to the UAN `/etc/sssd/sssd.conf` file in the `[domain]` section by CFS.
+
+    This example shows storing a value for `ldap_default_authtok`.  If more than one variable must be stored, they must be written in space separated `key=value` pairs on the same `vault write secret/uan_ldap` command line.
+
+    ```bash
+    ncn-m001# kubectl exec -it -n vault cray-vault-0 -- sh
+    export VAULT_ADDR=http://cray-vault:8200
+    vault login
+    vault write secret/uan_ldap ldap_default_authtok='TOKEN'
+    vault read secret/uan_ldap
+    ```
+
 ### SLE HPC Image for Application Nodes
 
-The UAN product provides an Application Node image which is based on SUSE Linux Enterprise High Performance Computing 15 (SLE HPC 15) and uses a "stock" (that is, not customized for HPE Cray systems) kernel. Customers can use this image on Application nodes that do not require any COS compatibility as UAN does. Unlike the default UAN image, this Application Node image is not based on the COS image. However, like the UAN default image, it is uploaded to IMS as part of the installation process.
+The UAN product provides an Application Node image. This image is based on SUSE Linux Enterprise High Performance Computing 15 (SLE HPC 15) and uses a "stock" (that is, not customized for HPE Cray systems) kernel. Customers can use this image on Application nodes that do not require any COS compatibility as UAN does. Unlike the default UAN image, this Application Node image is not based on the COS image. However, like the UAN default image, it is uploaded to IMS as part of the installation process.
 
 Customers must finish the installation or upgrade of the UAN product before booting an Application Node with SLE HPC 15 provided by that UAN product release. See [Booting an Application Node with a SLES Image (Technical Preview)](../advanced/SLES_Image.md) for more information about this image and instructions on deploying it to Application Nodes.
 
@@ -136,7 +150,7 @@ The following Nexus raw repositories are created:
 - uan-2.6.XX-sle-15sp4
 - uan-2.6.XX-sle-15sp3
 
-The following Nexus group repositories are created and reference the aforementioned Nexus raw repos.
+The following Nexus group repositories are created and reference the preceding Nexus raw repos.
 
 - uan-2.6-sle-15sp4
 - uan-2.6-sle-15sp3

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BIOS_of_an_HPE_UAN.md
@@ -8,7 +8,7 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
 
 1. Force a UAN to reboot into the BIOS.
 
-    In the following command, `UAN_BMC_XNAME` is the xname of the BMC of the UAN to configure. Replace `USER` and `PASSWORD` with the BMC username and password, respectively.
+    In the following command, `UAN_BMC_XNAME` is the xname of the BMC of the UAN to configure. Replace `USER` and `PASSWORD` with the BMC user name and password, respectively.
 
     ```bash
     ncn-m001# ipmitool -U USER -P PASSWORD -H UAN_BMC_XNAME -I lanplus \
@@ -22,7 +22,7 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
     lanplus sol activate
     ```
 
-    Refer to the section "About the ConMan Containerized Service" in the CSM documentation for more information about ConMan.
+    See also the section "About the ConMan Containerized Service" in the CSM documentation for more information about ConMan.
 
 3. Press the **ESC** and **9** keys to access the BIOS System Utilities when the option appears.
 
@@ -122,6 +122,6 @@ Perform [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iL
     ------------------------- 
     ```
 
-8. Refer to this [Setting the Date and Time](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00001068en_us&page=GUID-D7147C7F-2016-0901-0A72-000000000F34.html) in the HPE UEFI documentation to set the correct date and time.
+8. See this [Setting the Date and Time](https://support.hpe.com/hpesc/public/docDisplay?docId=sd00001068en_us&page=GUID-D7147C7F-2016-0901-0A72-000000000F34.html) in the HPE UEFI documentation to set the correct date and time.
 
    If the time is not set correctly, then PXE network booting issues may occur.

--- a/docs/portal/developer-portal/installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md
+++ b/docs/portal/developer-portal/installation_prereqs/Configure_the_BMC_for_UANs_with_iLO.md
@@ -18,7 +18,7 @@ Perform the first three steps of [Prepare for UAN Product Installation](Prepare_
 
    3. Wait for SSH to establish the connection.
 
-2. Open https://127.0.0.1:8443 in web browser on the NCN to access the BMC web GUI.
+2. Open https://127.0.0.1:8443 in a web browser on the NCN to access the BMC web GUI.
 
 3. Log in to the web GUI using default credentials.
 

--- a/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
+++ b/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
@@ -6,15 +6,15 @@ Install and configure the COS product before performing this procedure.
 
 1. Verify that the management network switches are properly configured.
 
-   Refer to the [switch configuration procedures](https://cray-hpe.github.io/docs-csm/en-14/install/csm-install/readme/#5-configure-management-network-switches) in the HPE Cray System Management Documentation.
+   See the [switch configuration procedures](https://cray-hpe.github.io/docs-csm/en-14/install/csm-install/readme/#5-configure-management-network-switches) in the HPE Cray System Management Documentation.
 
 2. Ensure that the management network switches have the proper firmware.
 
-    Refer to the procedure "Update the Management Network Firmware" in the HPE Cray EX hardware documentation.
+    See the procedure "Update the Management Network Firmware" in the HPE Cray EX hardware documentation.
 
 3. Ensure that the host reservations for the UAN CAN/CHN network have been properly set.
 
-    Refer to the procedure "Add UAN CAN IP Addresses to SLS" in the HPE Cray EX hardware documentation.
+    See the procedure "Add UAN CAN IP Addresses to SLS" in the HPE Cray EX hardware documentation.
 
 4. [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md)
 
@@ -36,7 +36,7 @@ Install and configure the COS product before performing this procedure.
     ncn-m001# tar zxf uan-PRODUCT_VERSION.tar.gz
     ```
 
-9. Navigate into the uan-PRODUCT_VERSION/ directory.
+9. Navigate into the `uan-PRODUCT_VERSION/` directory.
 
     ```bash
     ncn-m001# cd uan-PRODUCT_VERSION/
@@ -44,7 +44,7 @@ Install and configure the COS product before performing this procedure.
 
 10. Run the pre-install goss tests to determine if the system is ready for the UAN product installation.
 
-    This requires that goss is installed on the node running the tests.
+    This step requires that goss is installed on the node running the tests.
 
     ```bash
     ncn# ./validate-pre-install.sh
@@ -71,7 +71,7 @@ Install and configure the COS product before performing this procedure.
        ncn# PODS=$(kubectl get pods -n services -l app.kubernetes.io/name=cray-console-node --template '{{range .items}}{{.metadata.name}} {{end}}')
        ```
 
-    3. Use `conman -q` to scan the list of connections being monitored by conman (only UAN xnames are shown for brevity).
+    3. Use `conman -q` to scan the list of connections is monitoring (only UAN xnames are shown for brevity).
 
        ```bash
        ncn# for pod in $PODS; do kubectl exec -n services -c cray-console-node $pod -- conman -q; done

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -2,11 +2,11 @@
 
 ## UAN configuration overview
 
-Configuration of UAN nodes is performed by the Configuration Framework Service \(CFS\). CFS can apply configuration to both images and nodes. When the configuration is applied to nodes, the nodes must be booted and accessible through SSH over the Node Management Network \(NMN\).
+The Configuration Framework Service \(CFS\) performs the configuration of UAN nodes. CFS can apply configuration to both images and nodes. When the configuration is applied to nodes, the nodes must be booted and accessible through SSH over the Node Management Network \(NMN\).
 
-The preferred method of creating CFS configurations is to use the Shasta Admin Toolkit (SAT) `sat bootprep` command.  This command automates the creation of IMS images, CFS configurations, and BOS session templates. See [Create UAN Boot Images](Create_UAN_Boot_Images.md) for more details.
+The preferred method of creating CFS configurations is to use the Shasta Admin Toolkit (SAT) `sat bootprep` command. This command automates the manual process described in [Create UAN Boot Images](Create_UAN_Boot_Images.md). That process includes creating IMS images, CFS configurations, and BOS session templates.
 
-CFS uses configuration layers. Configuration layers allow the sharing of Ansible roles provided by other products, and by the site.  Non-root user access may be blocked during node configuration by enabling the `uan-set-nologin` and `uan-unset-nologin` configuration layers shown in the example bootprep file below. The parameterized fields are defined in a `product_vars.yml` file.
+CFS uses configuration layers. Configuration layers allow the sharing of Ansible roles provided by other products, and by the site. Non-root user access may be blocked during node configuration by enabling the `uan-set-nologin` and `uan-unset-nologin` configuration layers shown in the following example bootprep file. The parameterized fields are defined in a `product_vars.yml` file.
 
 **IMPORTANT** Do not remove or reorder the first three layers. The UAN product requires these layers and this specific order. Also, keep the required `cos-application-last` layer as the last or second to last layer in the configuration if `uan-set-nologin` and `uan-unset-nologin` are active.
 
@@ -68,12 +68,12 @@ CFS uses configuration layers. Configuration layers allow the sharing of Ansible
 
 ### Slingshot Host Software (playbook: shs_{{default.network_type}}_install.yml)
 
-The first CFS Layer installs the Slingshot Host Software for the Slingshot network type of the system.  The `default.network_type` is:
+The first CFS Layer installs the Slingshot Host Software for the Slingshot network type of the system. The `default.network_type` is:
 
 - `mellanox` for ConnectX-5 NICs used in Slingshot 10
 - `cassini` for Slingshot NICs in Slingshot 11
 
-The name of the playbook must match the name of the HSN NICs (Mellanox or Cassini) in the UAN nodes.  Additionally, the HSN NICs must be of the same type as the NCN and Compute nodes.
+The name of the playbook must match the name of the HSN NICs (Mellanox or Cassini) in the UAN nodes. Additionally, the HSN NICs must be of the same type as the NCN and Compute nodes.
 
 ### COS (playbook: cos-application.yml)
 
@@ -126,7 +126,7 @@ The following Ansible roles are run during UAN post-boot configuration:
 
 ### CMS Layer (playbook: csm_packages.yml)
 
-The third CFS Layer installs the Cray Management System packages. These are normally not modified.
+The third CFS Layer installs the Cray Management System packages. These packages are normally not modified.
 
 ### Optional UAN Layer (playbook: set_nologin.yml)
 
@@ -138,16 +138,16 @@ The Ansible roles involved in the UAN layer of the configuration are listed in t
 
 The UAN-specific roles involved in post-boot UAN node configuration are:
 
-- [`uan_disk_config`](uan_disk_config.md): this role configures the last disk found on the UAN that is smaller than 1TB, by default. That disk will be formatted with a scratch and swap partition mounted at /scratch and /swap, respectively. Each partition is 50% of the disk.
+- [`uan_disk_config`](uan_disk_config.md): this role configures the last disk found on the UAN that is smaller than 1TB, by default. That disk will be formatted with a scratch and swap partition mounted at `/scratch` and `/swap`, respectively. Each partition is 50% of the disk.
 - [`uan_packages`](uan_packages.md): this role installs any RPM packages listed in the uan-config-management repo.
 - [`uan_interfaces`](uan_interfaces.md): this role configures the UAN node networking. By default, this role does not configure a default route or the Customer Access Network \(CAN or CHN\) connection for the HPE Cray EX supercomputer. If CAN or CHN is enabled, the default route will be on the CAN or CHN. Otherwise, a default route must be set up in the customer interfaces definitions. Without the CAN or CHN, there will not be an external connection to the customer site network unless one is defined in the customer interfaces. See [Configure Interfaces on UANs](Configure_Interfaces_on_UANs.md).
 
   ***NOTE:*** If a UAN layer is used in the Compute node CFS configuration, the `uan_interfaces` role will configure the default route on Compute nodes to be on the HSN, if the BICAN System Default Route is set to `CHN`.
-- [`uan_motd`](uan_motd.md): this role Provides a default message of the day that can be customized by the administrator.
-- [`uan_ldap`](uan_ldap.md): this optional role configures the connection to LDAP servers. To disable this role, the administrator must set 'uan_ldap_setup:no' in the 'uan-config-management' VCS repository.
-- [`uan_hardening`](uan_hardening.md): This role configures site/customer-defined network security of UANs, for example, preventing ssh out of the UAN over the NMN to NCN nodes.
+- [`uan_motd`](uan_motd.md): this role Provides a default message of the day that the administrator can customize.
+- [`uan_ldap`](uan_ldap.md): this optional role configures the connection to LDAP servers. To disable this role, the administrator must set `uan_ldap_setup:no` in the `uan-config-management` VCS repository.
+- [`uan_hardening`](uan_hardening.md): This role configures site or customer-defined network security of UANs, for example, preventing SSH access from the UAN over the NMN to NCN nodes.
 
-The UAN roles in `site.yml` are required and must not be removed, with exception of `uan_ldap` if the site is using some other method of user authentication. The `uan_ldap` may also be skipped by setting the value of `uan_ldap_setup` to `no` in a `group_vars` or `host_vars` configuration file.  Configuration of this layer is made in the `uan-config-management` VCS repository.
+The UAN roles in `site.yml` are required and must not be removed, with exception of `uan_ldap` if the site is using some other method of user authentication. The `uan_ldap` may also be skipped by setting the value of `uan_ldap_setup` to `no` in a `group_vars` or `host_vars` configuration file. Configuration of this layer is made in the `uan-config-management` VCS repository.
 
 ### COS (playbook: cos-application-after.yml)
 
@@ -163,4 +163,4 @@ The following Ansible roles are run during UAN post-boot configuration:
 
 ### Optional UAN Layer (playbook: unset_nologin.yml)
 
-This UAN layer deletes the `/etc/nologin` file allowing non-root users to log into the UAN.  If the optional UAN layer that runs `set_nologin.yml` was used, this layer must be used or only the root user will have access to the node.
+This UAN layer deletes the `/etc/nologin` file allowing non-root users to log into the UAN. If the optional UAN layer that runs `set_nologin.yml` was used, this layer must be used or only the root user will have access to the node.

--- a/docs/portal/developer-portal/operations/Boot_UANs.md
+++ b/docs/portal/developer-portal/operations/Boot_UANs.md
@@ -2,7 +2,12 @@
 
 Perform this procedure to boot UANs using BOS so that they are ready for user logins.
 
-Perform [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) before performing this procedure.
+## Prerequisites
+
+- IUF is not being used to automate this process
+- [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md)
+
+## Procedure
 
 1. Create a BOS session to boot the UAN nodes. Replace `uan-sessiontemplate-PRODUCT_VERSION` in the following command with the ID of the session template created by the initial UAN product installation or the UAN product upgrade process.
 

--- a/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
+++ b/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
@@ -1,12 +1,12 @@
 
 # Build a New UAN Image Using a COS Recipe
 
-Prior to UAN 2.3, a similar copy of the COS image recipe was imported with the UAN install. Beginning with the UAN 2.3 release, UAN does not install an image recipe. A COS image recipe must be used. Additional UAN packages will be installed via CFS and the `uan_packages` role.  In UAN 2.6, this procedure is automated as part of the IUF process of installing and upgrading UAN.  See [Install or Upgrade UAN](../install/Install_the_UAN_Product_Stream.md) for details. 
+Prior to UAN 2.3, a similar copy of the COS image recipe was imported with the UAN install. Beginning with the UAN 2.3 release, UAN does not install an image recipe. A COS image recipe must be used. Additional UAN packages will be installed by CFS and the `uan_packages` role. In UAN 2.6, this procedure is automated as part of the IUF process of installing and upgrading UAN. See [Install or Upgrade UAN](../install/Install_the_UAN_Product_Stream.md) for details.
 
 The following procedures are provided for cases where a new UAN image must be built after initial installation. This document describes two methods of building UAN images:
 
-- [Using IUF to Build a New UAN Image (UAN 2.6+)](#using-iuf-to-build-a-new-uan-image-uan-26)
-- [Manually Build a New UAN Image from a COS Recipe (UAN 2.3+)](#manually-build-a-new-uan-image-from-a-cos-recipe-uan-23)
+- [Using IUF to Build a New UAN Image (UAN 2.6+)](#using-iuf-to-build-a-new-uan-image-uan-26): use this procedure if you are using the IUF automation and the UAN software release version is 2.6 or later.
+- [Manually Build a New UAN Image from a COS Recipe (UAN 2.3+)](#manually-build-a-new-uan-image-from-a-cos-recipe-uan-23): use this procedure if you are not using the IUF automation or the UAN software release is earlier than 2.6 and later than 2.3.
 
 ## Using IUF to Build a New UAN Image (UAN 2.6+)
 
@@ -21,7 +21,7 @@ Two IUF stages are run to create a new UAN image:
 
 After IUF runs these two stages, the UAN CFS configuration will be created, the UAN image will be configured using that configuration, and a UAN BOS session template will be created using the new configuration and image.
 
-Before using IUF to build a new UAN image from a COS recipe, be sure that the information in the IUF Recipe Variables file (`product_vars.yaml`) and bootprep file (`compute-and-uan-bootprep.yaml`) are correct for the desired UAN CFS configuration and the COS image recipe.
+Before using IUF to build a new UAN image from a COS recipe, be sure that the information in the IUF Recipe Variables file (`product_vars.yaml`) and bootprep file (`compute-and-uan-bootprep.yaml`) are correct for the wanted UAN CFS configuration and the COS image recipe.
 
 - Example `product_vars.yaml` showing COS and UAN versions and working VCS branches:
 
@@ -127,7 +127,7 @@ Before using IUF to build a new UAN image from a COS recipe, be sure that the in
     - Application_UAN
   ```
 
-After the `product_vars.yaml` and `compute-and-uan-bootprep.yaml` files are updated to reflect the desired COS and UAN versions and VCS branches to use, IUF may be executed.
+After the `product_vars.yaml` and `compute-and-uan-bootprep.yaml` files are updated to reflect the wanted COS and UAN versions and VCS branches to use, IUF may be executed.
 
 ## Manually Build a New UAN Image from a COS Recipe (UAN 2.3+)
 
@@ -136,7 +136,7 @@ Perform the following before starting this procedure:
 - Install the COS, Slingshot, and UAN product streams.
 - Initialize the cray administrative CLI.
 
-In the COS recipe for 2.2, several dependencies have been removed, this includes Slingshot, DVS, and Lustre. Those packages are now installed during CFS Image Customization. More information on this change is covered in the [Create UAN Boot Images](Create_UAN_Boot_Images.md) procedure.
+In the COS recipe for 2.2, several dependencies have been removed, including Slingshot, DVS, and Lustre. Those packages are now installed during CFS Image Customization. More information on this change is covered in the [Create UAN Boot Images](Create_UAN_Boot_Images.md) procedure.
 
 1. Identify the COS image recipe to base the UAN image on. Select the recipe that matches the version of COS that the compute nodes will be using.
 

--- a/docs/portal/developer-portal/operations/CVE-2023-0461.md
+++ b/docs/portal/developer-portal/operations/CVE-2023-0461.md
@@ -3,27 +3,27 @@
 
 ## Description
 
-> There is a use-after-free vulnerability in the Linux Kernel which can be exploited to achieve local privilege escalation. To reach the vulnerability kernel configuration flag CONFIG_TLS or CONFIG_XFRM_ESPINTCP has to be configured, but the operation does not require any privilege. There is a use-after-free bug of icsk_ulp_data of a struct inet_connection_sock. When CONFIG_TLS is enabled, user can install a tls context (struct tls_context) on a connected tcp socket. The context is not cleared if this socket is disconnected and reused as a listener. If a new socket is created from the listener, the context is inherited and vulnerable. The setsockopt TCP_ULP operation does not require any privilege. We recommend upgrading past commit 2c02d41d71f90a5168391b6a5f2954112ba2307c
+> There is a use-after-free vulnerability in the Linux Kernel which can be exploited to achieve local privilege escalation. To reach the vulnerability kernel configuration flag CONFIG_TLS or CONFIG_XFRM_ESPINTCP has to be configured, but the operation does not require any privilege. There is a use-after-free bug of icsk_ulp_data of a struct inet_connection_sock. When CONFIG_TLS is enabled, a user can install a TLS context (struct tls_context) on a connected TCP socket. The context is not cleared if this socket is disconnected and reused as a listener. If a new socket is created from the listener, the context is inherited and vulnerable. The setsockopt TCP_ULP operation does not require any privilege. We recommend upgrading past commit 2c02d41d71f90a5168391b6a5f2954112ba2307c
 
 [CVE-2023-0461](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-0461)
 
-Current status from SUSE:
+Status from SUSE:
 https://www.suse.com/security/cve/CVE-2023-0461.html
 
 ## Mitigation
 
 While the underlying CVE is being addressed by SUSE, UANs can mitigate this issue by unbonding the CAN (if it is being used), and unloading the TLS kernel module after blocking the kernel from being loaded again.
 
-The mitigation script provided below will perform the following actions:
+The following mitigation script will perform the following actions:
 1. Select the first `BONDING_SLAVE0` from `ifcfg-bond0` if it exists
 1. Replace `bond0` in `ifcfg-can0` with the `BONDING_SLAVE0` interface
 1. Reload interfaces
-1. Add a blacklist for the tls module
+1. Add a deny list for the `tls` module
 1. Unload `bonding` and `tls` kernel modules provided `mlx5_core` is not present
 1. Fail if `mlx5_core` is detected to highlight that the mitigation failed
 
 *Important*: This mitigation is intended for UANs that meet the following criteria:
-* The UANs are connected to HPE Aruba Networking switches (`lcap-individual` must be set for other switch types to allow for unbonded CAN connections)
+* The UANs are connected to HPE Aruba network switches (`lcap-individual` must be set for other switch types to allow for unbonded CAN connections)
 * The UANs use HPE Slingshot HSN NICs and not Mellanox ConnectX-5 HSN NICs.
 
 ## Procedure
@@ -80,4 +80,4 @@ index 674ab30..ad166cf 100644
 +      script: mitigate-uan-cve-2023-0461.sh
 ```
 
-Once UAN images are built to address the CVE, this mitigation script should be removed.
+After UAN images are built to address the CVE, remove this mitigation script.

--- a/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Interfaces_on_UANs.md
@@ -3,38 +3,38 @@
 
 Perform this procedure to configure network interfaces on UANs by editing a configuration file.
 
-Interface configuration is performed by the `uan_interfaces` Ansible role. For details on the variables referred to in this procedure, see [`uan_interfaces`](uan_interfaces.md).
+The `uan_interfaces` Ansible role performs interface configuration. For details on the variables used in this procedure, see [`uan_interfaces`](uan_interfaces.md).
 
 In the command examples of this procedure, `PRODUCT_VERSION` refers to the current installed version of the UAN product. Replace `PRODUCT_VERSION` with the UAN version number string when executing the commands.
 
 ## Node Management Networking
 
-By default, the Node Management Network \(NMN\) is connected to a single `nmn0` interface.  If desired, and the system networking is configured to support it, the Node Management Network may be configured as a bonded interface, `nmnb0`. To configure the NMN as a bonded pair, set `uan_nmn_bond` to true and set the interfaces to be used in the bond in `uan_nmn_bond_slaves` as described in [`uan_interfaces`](uan_interfaces.md).
+By default, the Node Management Network \(NMN\) is connected to a single `nmn0` interface. If wanted, and the system networking is configured to support it, the Node Management Network may be configured as a bonded interface, `nmnb0`. To configure the NMN as a bonded pair, set `uan_nmn_bond` to true and set the interfaces to be used in the bond in `uan_nmn_bond_slaves` as described in [`uan_interfaces`](uan_interfaces.md).
 
 ### Prerequisites for Bonded NMN
 
-To enable NMN bonding, certain features in iPXE and the management switches connected to the UAN NMN interfaces must be enabled.  These features are enabled in the following CSM and CANU versions:
+To enable NMN bonding, certain features in iPXE and the management switches connected to the UAN NMN interfaces must be enabled. These features are enabled in the following CSM and CANU versions:
 
 * CSM-1.3.2 and newer enable the iPXE features
 * CANU-1.7.0 and newer enables the management switch features
 
 ## User Access Networking
 
-User access may be configured to use either a direct connection to the UANs from the site's user network, or one of two optional user access networks implemented within the HPE Cray EX system.  The two optional networks are the Customer Access Network \(CAN\) and Customer High Speed Network \(CHN\).  The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
+User access may be configured to use either a direct connection to the UANs from the site's user network, or one of two optional user access networks implemented within the HPE Cray EX system. The two optional networks are the Customer Access Network \(CAN\) and Customer High Speed Network \(CHN\). The CAN is a VLAN on the Node Management Network \(NMN\), whereas the CHN is over the High Speed Network \(HSN\).
 
-By default, a direct connection to the site's user network is assumed and the Admin must define the interface(s) and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.
+By default, a direct connection to the site's user network is assumed and the Admin must define one or more interfaces and default route using the `customer_uan_interfaces` and `customer_uan_routes` structures. If `uan_can_setup` is a true value, user access will be over CAN or CHN depending on what the system default route is set to in SLS.
 
-* When CAN is set as the system default route in SLS and `uan_nmn_bond` is false, the bonded CAN interfaces are determined automatically.  If `uan_nmn_bond` is true, the bonded CAN interfaces must be defined by `uan_can_bond_slaves` \(see [`uan_interfaces`](uan_interfaces.md)\). The default route is set to the bonded CAN interface `can0`.
+* When CAN is set as the system default route in SLS and `uan_nmn_bond` is false, the bonded CAN interfaces are determined automatically. If `uan_nmn_bond` is true, the bonded CAN interfaces must be defined by `uan_can_bond_slaves` \(see [`uan_interfaces`](uan_interfaces.md)\). The default route is set to the bonded CAN interface `can0`.
 
-* When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` by default, but can be changed by setting `uan_chn_device` to the desired interface. The default route is set to the CHN.
+* When CHN is set as the system default route in SLS, the CHN IP is added to `hsn0` by default, but can be changed by setting `uan_chn_device` to the wanted interface. The default route is set to the CHN.
 
 * The Admin may override the CAN/CHN default route by setting `uan_customer_default_route` to true and defining the default route in `customer_uan_routes`.
 
 ## Procedure
 
-Network configuration settings are defined in the `uan-config-management` VCS repo under the `group_vars/ROLE_SUBROLE/` or `host_vars/XNAME/` directories, where `ROLE_SUBROLE` must be replaced by the role and subrole assigned for the node in HSM, and `XNAME` with the xname of the node. Values under `group_vars/ROLE_SUBROLE/` apply to all nodes with the given role and subrole.  Values under the `host_vars/XNAME/` apply to the specific node with the xname and will override any values set in `group_vars/ROLE_SUBROLE/`.  A yaml file is used by the Configuration Framework Service \(CFS\).  The examples in this procedure use `customer_net.yml`, but any filename may be used.  Admins must create this yaml file and use the variables described in this procedure.
+Network configuration settings are defined in the `uan-config-management` VCS repo under the `group_vars/ROLE_SUBROLE/` or `host_vars/XNAME/` directories, where `ROLE_SUBROLE` must be replaced by the role and subrole assigned for the node in HSM, and `XNAME` with the xname of the node. Values under `group_vars/ROLE_SUBROLE/` apply to all nodes with the given role and subrole. Values under the `host_vars/XNAME/` apply to the specific node with the xname and will override any values set in `group_vars/ROLE_SUBROLE/`. A yaml file is used by the Configuration Framework Service \(CFS\). The examples in this procedure use `customer_net.yml`, but any filename may be used. Admins must create this yaml file and use the variables described in this procedure.
 
-If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `yes` in the yaml file.  The UAN will be configured to use the CAN or CHN based on what the BICAN System Default Route is set to in SLS.
+If the HPE Cray EX CAN or CHN is wanted, set the `uan_can_setup` variable to `yes` in the yaml file. The UAN will be configured to use the CAN or CHN based on what the BICAN System Default Route is set to in SLS.
 
 1. Obtain the password for the `crayvcs` user.
 
@@ -251,7 +251,7 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     - the `lastUpdated` line
     - the last `name` line
         
-    These must be removed before uploading the modified JSON file back into CFS to update the UAN configuration.
+    These lines must be removed before uploading the modified JSON file back into CFS to update the UAN configuration.
 
     ```bash
     ncn-m001# cat uan-config-PRODUCT_VERSION.json
@@ -271,7 +271,7 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
 
     c. Replace the `commit` value in the JSON file with the commit ID obtained in the previous Step.
 
-    The name value after the commit line may also be updated to match the new UAN product version, if desired. This is not necessary as CFS does not use this value for the configuration name.
+    The name value after the commit line may also be updated to match the new UAN product version, if wanted. This update is not necessary as CFS does not use this value for the configuration name.
 
     ```bash
     {
@@ -286,7 +286,7 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     }
     ```
 
-    d. Create a new UAN CFS configuration with the updated JSON file.
+    d. Create a UAN CFS configuration with the updated JSON file.
 
        The following example uses `uan-config-PRODUCT_VERSION` for the name of the new CFS configuration, to match the JSON file name.
 
@@ -295,7 +295,7 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
     --file uan-config-PRODUCT_VERSION.json
     ```
 
-    e. Tell CFS to apply the new configuration to UANs by repeating the following command for each UAN. Replace `UAN_XNAME` in the command below with the name of a different UAN each time the command is run.
+    e. Tell CFS to apply the new configuration to UANs by repeating the following command for each UAN. Replace `UAN_XNAME` in the following command with the name of a different UAN each time the command is run.
 
     ```
     ncn-m001# cray cfs components update --desired-config uan-config-PRODUCT_VERSION \
@@ -312,5 +312,5 @@ If the HPE Cray EX CAN or CHN is desired, set the `uan_can_setup` variable to `y
      --template-uuid UAN_SESSION_TEMPLATE --operation reboot
     ```
 
-10. Verify that the desired networking configuration is correct on each UAN.
+10. Verify that the wanted network configuration is correct on each UAN.
 

--- a/docs/portal/developer-portal/operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md
+++ b/docs/portal/developer-portal/operations/Configure_Pluggable_Authentication_Modules_(PAM)_on_UANs.md
@@ -1,9 +1,9 @@
 
 # Configure Pluggable Authentication Modules \(PAM\) on UANs
 
-Perform this procedure to configure PAM on UANs. This enables dynamic authentication support for system services.
+Perform this procedure to configure PAM on UANs. PAM enables dynamic authentication support for system services.
 
-Initialize and configure the Cray command line interface \(CLI\) tool on the system. See "Configure the Cray Command Line Interface \(CLI\)" in the CSM documentation for more information.
+Initialize and configure the Cray CLI tool on the system. See "Configure the Cray Command Line Interface \(CLI\)" in the CSM documentation for more information.
 
 1. Verify that the Gitea Version Control Service \(VCS\) is running.
 
@@ -13,7 +13,7 @@ Initialize and configure the Cray command line interface \(CLI\) tool on the sys
     services          gitea-vcs-postgres-0               2/2     Running             0          11d
     ```
 
-2. Retrieve the initial Gitea login credentials for the `crayvcs` username.
+2. Retrieve the initial Gitea login credentials for the `crayvcs` user name.
 
     ```bash
     ncn-m001# kubectl get secret -n services vcs-user-credentials \
@@ -43,7 +43,7 @@ Initialize and configure the Cray command line interface \(CLI\) tool on the sys
 
 6. Make a new directory for the PAM configuration.
 
-    a. Create a `group_vars/all` directory if making changes to all UANs.
+    a. Create a `group_vars/all` directory if changing all UANs.
 
     ```bash
     ncn-w001# mkdir -p group_vars/all

--- a/docs/portal/developer-portal/operations/uan_disk_config.md
+++ b/docs/portal/developer-portal/operations/uan_disk_config.md
@@ -7,17 +7,17 @@ nodes.
 
 There must be disk devices found on the UAN node by the `device_filter` module
 or this role will exit with failure. This condition can be ignored by setting
-`uan_require_disk` to `false`. See variable definitions below.
+`uan_require_disk` to `false`. See the following list for variable definitions.
 
 See the `library/device_filter.py` file for more information on this module.
 
 The device that is found will be unmounted if mounted and a swap partition will
-be created on the first half of the disk, and a scratch partition on the second
+be created on the first half of the disk. A scratch partition will be created on the second
 half. ext4 filesystems are created on each partition.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are in the following list, including default values (see `defaults/main.yml`):
 
 `uan_require_disk`
 
@@ -54,7 +54,7 @@ Input to the `device_filter` module.
 
 `uan_device_model_filter`
 
-: Regular expression of device model for this role to filter.
+: Regular expression of the device model for this role to filter.
 Input to the `device_filter` module.
 
   Example:
@@ -65,7 +65,7 @@ Input to the `device_filter` module.
 
 `uan_device_vendor_filter`
 
-: Regular expression of disk vendor for this role to filter.
+: Regular expression of the disk vendor for this role to filter.
 Input to the `device_filter` module.
 
   Example:
@@ -127,7 +127,7 @@ Input to the `device_filter` module.
 
 `swap_swappiness`
 
-: Value to set the swapiness in sysctl.
+: Value to set the `swapiness` in `sysctl`.
 
   Example:
 

--- a/docs/portal/developer-portal/operations/uan_gpg_keys.md
+++ b/docs/portal/developer-portal/operations/uan_gpg_keys.md
@@ -6,12 +6,12 @@ The `uan_gpg_keys` role installs the CSM GPG signing public key. This role is a 
 ## Requirements
 
 The Kubernetes secret must be available in the namespace and field specified
-by the `uan_gpg_key_*` variables below. The key must be stored as a base64-encoded
+by the following `uan_gpg_key_*` variables. The key must be stored as a base64-encoded
 string.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (located in
+Available variables are in the following list, including default values (defined in
 `defaults/main.yml`):
 
 `uan_gpg_key_k8s_secret`

--- a/docs/portal/developer-portal/operations/uan_hardening.md
+++ b/docs/portal/developer-portal/operations/uan_hardening.md
@@ -1,7 +1,7 @@
 # `uan_hardening`
 
-The `uan_hardening` role configures site/customer-defined network security
- of UANs, for example preventing ssh out of UAN over NMN to NCN nodes.
+The `uan_hardening` role configures site or customer-defined network security
+ of UANs, for example preventing SSH access from the UAN over the NMN to NCN nodes.
 
 ## Requirements
 
@@ -9,12 +9,12 @@ None.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are in the following list, including default values (see `defaults/main.yml`):
 
 `disable_ssh_out_nmn_to_management_ncns`
 
-: Boolean variable controlling whether or not firewall rules are applied at the UAN to
-prevent ssh outbound over the NMN to the NCN management nodes.
+: Boolean variable controlling whether firewall rules are applied at the UAN to
+prevent SSH outbound over the NMN to the NCN management nodes.
 
 The default value of `disable_ssh_out_nmn_to_management_ncns` is `yes`.
 
@@ -24,8 +24,8 @@ disable_ssh_out_nmn_to_management_ncns: yes
 
 `disable_ssh_out_uan_to_nmn_lb`
 
-: Boolean variable controlling whether or not firewall rules are applied at the UAN to
-prevent ssh outbound over the NMN to NMN LB IPs.
+: Boolean variable controlling whether firewall rules are applied at the UAN to
+prevent SSH outbound over the NMN to NMN LB IP addresses.
 
 The default value of `disable_ssh_out_uan_to_nmn_lb` is `yes`.
 

--- a/docs/portal/developer-portal/operations/uan_interfaces.md
+++ b/docs/portal/developer-portal/operations/uan_interfaces.md
@@ -1,6 +1,6 @@
 # `uan_interfaces`
 
-The `uan_interfaces` role configures site/customer-defined network interfaces
+The `uan_interfaces` role configures site or customer-defined network interfaces
 and Shasta Customer Access Network (CAN) network interfaces on UAN nodes.
 
 ## Requirements
@@ -9,7 +9,7 @@ None.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are in the following list, including default values (see `defaults/main.yml`):
 
 `uan_nmn_bond`
 
@@ -28,20 +28,20 @@ uan_nmn_bond: no
 
 : A list of the interfaces to use as the bond slave pair when `uan_nmn_bond` is true.
 
-The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f0`
+The interface names must be in a format which does not change between reboots of the node, such as `ens10f0`
 which is the first port of the NIC in slot 10.  
 
 **NOTE:** `ens10f0` is typically the first port of the OCP 25Gb card that
 the node PXE boots.
 
 **IMPORTANT:** The first interface in the list must be the `nmn0` interface which is configured during the
-initial image boot, typically `ens10f0`.  This is required because the MAC address of the `nmn0` interface
-is the MAC associated with the IP address of the UAN.  The bonded `nmnb0` interface and the bond slaves
+initial image boot, typically `ens10f0`. This interface order is required because the MAC address of the `nmn0` interface
+is the MAC associated with the IP address of the UAN. The bonded `nmnb0` interface and the bond slaves
 will assume this MAC and the IP address of `nmn0` to preserve connectivity.
 
 The second interface is typically the first port of a different 25Gb NIC for resiliency.
 
-The default values of `uan_nmn_bond_slaves` are shown here.  They may need to be changed to match the actual
+The default values of `uan_nmn_bond_slaves` are shown here. Change them as needed to match the actual
 node cabling and NIC configuration.
 
 ```yaml
@@ -53,11 +53,11 @@ uan_nmn_bond_slaves:
 `uan_can_setup`
 
 : Boolean variable controlling the configuration of user
-access to UAN nodes.  When true, user access is configured over either the
+access to UAN nodes. When true, user access is configured over either the
 Customer Access Network (CAN) or Customer High Speed Network (CHN), depending on which is configured on the system.
 
 When `uan_can_setup` is false, user access over the CAN or CHN is not configured
-on the UAN nodes and no default route is configured.  The Admin must then specify
+on the UAN nodes, and no default route is configured. The Admin must then specify
 the default route in `customer_uan_routes`.
 
 The default value of `uan_can_setup` is `no`.
@@ -68,9 +68,9 @@ uan_can_setup: no
 
 `uan_can_bond_slaves`
 
-: A list of the interfaces to use as the bond slave pair when `uan_can_setup` is true, `uan_nmn_bond` is true, and the Customer Access Network (CAN) is configured on the system.  This variable is ignored if `uan_nmn_bond` is false.
+: A list of the interfaces to use as the bond slave pair when `uan_can_setup` is true, `uan_nmn_bond` is true, and the Customer Access Network (CAN) is configured on the system. This variable is ignored if `uan_nmn_bond` is false.
 
-The interface names must be in a format which doesn't change between reboots of the node, such as `ens10f1`
+The interface names must be in a format which does not change between reboots of the node, such as `ens10f1`
 which is the second port of the NIC in slot 10.  
 
 **NOTE:** `ens10f1` is typically the second port of the OCP 25Gb card and is used as one of the bond
@@ -78,7 +78,7 @@ slaves in the CAN `bond0` interface.
 
 The second interface is typically the second port of a different 25Gb NIC for resiliency.
 
-The default values of `uan_can_bond_slaves` are shown here.  They may need to be changed to match the actual
+The default values of `uan_can_bond_slaves` are shown here. They may need to be changed to match the actual
 node cabling and NIC configuration.
 
 ```yaml
@@ -111,7 +111,7 @@ uan_customer_default_route: no
 `sls_nmn_name`
 
 : Node Management Network name used by SLS.
-This value should not be changed.
+This value must not be changed.
 
 ```yaml
 sls_nmn_name: "NMN"
@@ -120,7 +120,7 @@ sls_nmn_name: "NMN"
 `sls_nmn_svcs_name`
 
 : Node Management Services Network name used by SLS.
-This value should not be changed.
+This value must not be changed.
 
 ```yaml
 sls_nmn_svcs_name: "NMNLB"
@@ -129,7 +129,7 @@ sls_nmn_svcs_name: "NMNLB"
 `sls_mnmn_svcs_name`
 
 : Mountain Node Management Services Network name used
-by SLS.  This value should not be changed.
+by SLS. This value must not be changed.
 
 ```yaml
 sls_mnmn_svcs_name: "NMN_MTN"
@@ -137,7 +137,7 @@ sls_mnmn_svcs_name: "NMN_MTN"
 
 `uan_required_dns_options`
 
-: List of DNS options.  By default, `single-request` is set and must not be removed.
+: List of DNS options. By default, `single-request` is set and must not be removed.
 
 ```yaml
 uan_required_dns_options:
@@ -147,11 +147,11 @@ uan_required_dns_options:
 `customer_uan_interfaces`
 
 : List of interface names used for constructing
-`ifcfg-<customer_uan_interfaces.name>` files. Define ifcfg fields for each
+`ifcfg-<customer_uan_interfaces.name>` files. Define the ifcfg fields for each
 interface here. Field names are converted to uppercase in the generated
-`ifcfg-<name>` file(s).
+`ifcfg-<name>` file or files.
 
-Interfaces should be defined in order of dependency.
+Interfaces must be defined in order of dependency.
 
 ```yaml
 customer_uan_interfaces: []
@@ -269,7 +269,7 @@ external_dns_options:
 `uan_access_control`
 
 : Boolean variable to control whether non-root access
-control is enabled.  Default is `no`.
+control is enabled. Default is `no`.
 
 ```yaml
 uan_access_control: no

--- a/docs/portal/developer-portal/operations/uan_ldap.md
+++ b/docs/portal/developer-portal/operations/uan_ldap.md
@@ -8,11 +8,11 @@ NSCD, pam-config, sssd.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are in the following list, including default values (see `defaults/main.yml`):
 
 `uan_ldap_setup`
 
-: A Boolean variable to selectively skip the setup of LDAP on nodes it would otherwise be configured due to `uan_ldap_config` being defined.  The default setting is to setup LDAP when `uan_ldap_config` is not empty.
+: A Boolean variable to selectively skip the setup of LDAP on nodes it would otherwise be configured due to `uan_ldap_config` being defined. The default setting is to setup LDAP when `uan_ldap_config` is not empty.
 
   Example:
 
@@ -22,7 +22,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 `uan_ldap_config`
 
-: Configures LDAP domains and servers. If this list is empty, no LDAP configuration will be applied to the UAN targets and all role tasks will be skipped.
+: Configures LDAP domains and servers. If this list is empty, no LDAP configuration will be applied to the UAN targets, and all role tasks will be skipped.
 
   Example:
 

--- a/docs/portal/developer-portal/operations/uan_motd.md
+++ b/docs/portal/developer-portal/operations/uan_motd.md
@@ -8,7 +8,7 @@ None.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are in the following list, including default values (see `defaults/main.yml`):
 
 ```yaml
 uan_motd_content: []

--- a/docs/portal/developer-portal/operations/uan_packages.md
+++ b/docs/portal/developer-portal/operations/uan_packages.md
@@ -5,7 +5,7 @@ using the Ansible `zypper_repository` and `zypper` module.
 
 Repositories and packages added to this role will be installed or removed during
 image customization. Installing RPMs during post-boot node configuration can
-cause high system loads on large systems so these tasks runs only during image
+cause high system loads on large systems so these tasks run only during image
 customizations.
 
 This role will only run on SLES-based nodes.
@@ -19,18 +19,18 @@ is false.
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see defaults/main.yml):
+Available variables are in the following list, including default values (see defaults/main.yml):
 
 This role uses the `zypper_repository` module. The `name`, `description`, `repo`,
 `disable_gpg_check`, and `priority` fields are supported.
 
-This role uses the `zypper` modules.  The `name` and `disable_gpg_check` fields are supported.
+This role uses the `zypper` modules. The `name` and `disable_gpg_check` fields are supported.
 
 `uan_disable_gpg_check`
 
 : Sets the `disable_gpg_check` field on Zypper repos and
 packages listed in the `uan_sles15_repositories add` and `uan_sles15_packages_add`
-lists.  The `disable_gpg_check` field can be overridden for each repo or package.
+lists. The `disable_gpg_check` field can be overridden for each repo or package.
 
 `uan_sles15_repositories_add`
 

--- a/docs/portal/developer-portal/operations/uan_shadow.md
+++ b/docs/portal/developer-portal/operations/uan_shadow.md
@@ -8,7 +8,7 @@ The root password hash has to be installed in HashiCorp Vault at `secret/uan roo
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are in the following list, including default values (see `defaults/main.yml`):
 
 `uan_vault_url`
 

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Boot_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Boot_Issues.md
@@ -21,7 +21,7 @@ UAN boots are performed in three phases:
 
 ## PXE Issues
 
-Most PXE boot failures are the result of misconfigured network switches and/or BIOS settings. The UAN must PXE boot over the Node Management Network \(NMN\) and the switches must be configured to allow connectivity to the NMN. The cable for the NMN must be connected to the first port of the OCP card on HPE DL325 and DL385 servers. See "Prepare for UAN Product Installation" in the UAN Installation Guide for details on the switch and BIOS settings required to configure the UAN for PXE booting.
+Most PXE boot failures are the result of misconfigured network switches, BIOS settings or both. The UAN must PXE boot over the Node Management Network \(NMN\) and the switches must be configured to allow connectivity to the NMN. The cable for the NMN must be connected to the first port of the OCP card on HPE DL325 and DL385 servers. See "Prepare for UAN Product Installation" in the UAN Installation Guide for details on the switch and BIOS settings required to configure the UAN for PXE booting.
 
 UANs may fail to boot when the BIOS EFITIME is too far away from the time on management nodes. If there are x509 certificate problems, check that the BIOS time is correct. See "Configure the BIOS of an HPE UAN" in the UAN Installation Guide for examples of checking settings in the BIOS.
 
@@ -29,9 +29,9 @@ UANs may fail to boot when the BIOS EFITIME is too far away from the time on man
 
 Dracut failures are often caused by the wrong interface being named `nmn0`, or to multiple entries for the UAN xname in DNS. The latter is a result of multiple interfaces making DHCP requests. Either condition can cause IP address mismatches in the `dvs_node_map`. DNS configures entries based on DHCP leases.
 
-When dracut starts, it renames the network device named by the `ifmap=netX:nmn0` kernel parameter to `nmn0`. This interface is the only one dracut will enable DHCP on. The `ip=nmn0:dhcp` kernel parameter limits dracut to DHCP only `nmn0`. The ifmap value must be set correctly in the `kernel_parameters` field of the BOS session template.
+When dracut starts, it renames the network device named by the `ifmap=netX:nmn0` kernel parameter to `nmn0`. This interface is the only one dracut will enable DHCP on. The `ip=nmn0:dhcp` kernel parameter limits dracut to DHCP only `nmn0`. The `ifmap` value must be set correctly in the `kernel_parameters` field of the BOS session template.
 
-See [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) for details on how to configure the BOS session template. For UAN nodes that have more than one PCI card installed, `ifmap=net2:nmn0` is the correct setting. If only one PCI card is installed, `ifmap=net0:nmn0` is normally the correct setting.
+See [Create UAN Boot Images](../operations/Create_UAN_Boot_Images.md) for details on how to configure the BOS session template manually when not using the IUF automation. For UAN nodes that have more than one PCI card installed, `ifmap=net2:nmn0` is the correct setting. If only one PCI card is installed, `ifmap=net0:nmn0` is normally the correct setting.
 
 UANs require CPS and DVS to boot from images. These services are configured in dracut to retrieve the rootfs and mount it. If the image fails to download, check that DVS and CPS are both healthy, and DVS is running on all worker nodes. Run the following commands to check DVS and CPS:
 
@@ -51,7 +51,7 @@ If DVS and CPS are both healthy, then both of these commands will return all the
 
 ## Image Boot Issues
 
-Once dracut exits, the UAN will boot the `rootfs` image. Failures seen in this phase tend to be failures of `spire-agent`, `cfs-state-reporter`, or both. The `cfs-state-reporter` tells BOA that the node is ready and allows BOA to start CFS for Node Personalization. If `cfs-state-reporter` does not start, check if the `spire-agent` has started. The `cfs-state-reporter` depends on the `spire-agent`. Running systemctl status spire-agent will show that that service is enabled and running if there are no issues with that service. Similarly, running `systemctl status cfs-state-reporter` will show a status of SUCCESS.
+After dracut exits, the UAN will boot the `rootfs` image. Failures seen in this phase tend to be failures of `spire-agent`, `cfs-state-reporter`, or both. The `cfs-state-reporter` tells BOA that the node is ready and allows BOA to start CFS for Node Personalization. If `cfs-state-reporter` does not start, check if the `spire-agent` has started. The `cfs-state-reporter` depends on the `spire-agent`. Running systemctl status spire-agent will show that that service is enabled and running if there are no issues with that service. Similarly, running `systemctl status cfs-state-reporter` will show a status of SUCCESS.
 
 ```bash
 uan# systemctl status spire-agent
@@ -77,4 +77,4 @@ FAILED Failed to start Load Kernel Modules.
 See 'systemctl status systemd-modules-load.service' for details.
 ```
 
-Provided the UAN boots and completes post boot customizations, these messages may be ignored.
+Provided the UAN boots and completes post-boot customizations, these messages may be ignored.

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_CFS_and_Network_Configuration_Issues.md
@@ -13,7 +13,7 @@ Read [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) before 
     ncn# kubectl -n services get pods --sort-by=.metadata.creationTimestamp | grep ^cfs
     ```
 
-2. View the Ansible log of the CFS session found in the previous step \(CFS\_SESSION in the following example\). Use the information in log to guide troubleshooting.
+2. View the Ansible log of the CFS session found in the previous step \(CFS\_SESSION in the following example\). Use the information in the log to guide troubleshooting.
 
     ```bash
     ncn# kubectl -n services logs -f -c ansible-0 CFS_SESSION

--- a/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md
+++ b/docs/portal/developer-portal/troubleshooting/Troubleshoot_UAN_Disk_Configuration_Issues.md
@@ -5,7 +5,7 @@ Perform this procedure to enable `uan_disk_config` to run successfully by erasin
 
 This procedure currently only addresses `uan_disk_config` errors due to existing disk partitions.
 
-Refer to [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) for an explanation of UAN disk configuration.
+See [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) for an explanation of UAN disk configuration.
 
 The most common cause of failure in the `uan_disk_config` role is the disk having been previously configured without a `/scratch` and `/swap` partition. Existing partitions prevent the `parted` command from dividing the disk into those two equal partitions. The solution is to log into the node and run `parted` manually to remove the existing partitions on that disk.
 
@@ -13,7 +13,7 @@ The most common cause of failure in the `uan_disk_config` role is the disk havin
 
 2. Log into the affected UAN as root.
 
-3. Use parted to manually remove any existing partitions.
+3. Use `parted` to manually remove any existing partitions.
 
     The following example uses `/dev/sdb` as the disk device. Also, as partitions are removed, the remaining partitions are renumbered. Therefore, `rm 1` is issued twice to remove both partitions.
 

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -2,7 +2,7 @@
 
 The following guide describes changes included in a particular UAN version that may be of note during an install or upgrade.
 
-When an upgrade is being performed, please review the notable changes for **all** of the UAN versions up to the version being installed. If a particular version does not appear in this guide, it may have only had minor changes. For a full account of the changes involved in a release, consult the ChangeLog.md file at the root of the UAN product repository.
+When an upgrade is being performed, review the notable changes for **all** the UAN versions up to the version being installed. If a particular version does not appear in this guide, it may have only had minor changes. For a full account of the changes involved in a release, consult the ChangeLog.md file at the root of the UAN product repository.
 
 ## UAN 2.2
 
@@ -14,16 +14,16 @@ When an upgrade is being performed, please review the notable changes for **all*
 * The role `uan_packages` will now install the rpms needed by UAN and Application Nodes
 * The role `uan_packages` supports GPG checking when the CSM version is 1.2 or greater.
   * `uan_disable_gpg_check: yes` must be set if CSM is earlier than 1.2
-  * `uan_disable_gpg_check: no` should be set if CSM is 1.2 or greater
+  * `uan_disable_gpg_check: no` must be set if CSM is 1.2 or greater
 
 ## UAN 2.4.0
 
 * UAN 2.4.0 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.  
-  * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customers user network.  By default, a direct connection is selected as it was in previous releases.  
+  * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customer user network.  By default, a direct connection is selected as it was in previous releases.  
     * `uan_can_setup`, when set to `yes`, selects the customer access network implementation based on the setting of the BICAN System Default Route in SLS.
     * Application nodes may now set a default route other than the CAN or CHN default route when `uan_can_setup: yes`.
-    * `uan_customer_default_route: true` will allow a customer defined default route to be set using the `customer_uan_routes` structure when `uan_can_setup` is set to `yes`.
-* `sat bootprep` is now used in the documentation to streamline the IMS, CFS, and BOS commands to create and customize images and creating sessiontemplates.
+    * `uan_customer_default_route: true` will allow a customer-defined default route to be set using the `customer_uan_routes` structure when `uan_can_setup` is set to `yes`.
+* `sat bootprep` is now used in the documentation to streamline the IMS, CFS, and BOS commands to create and customize images and creating `sessiontemplate` files.
 
 ## UAN 2.4.1
 
@@ -37,7 +37,7 @@ When an upgrade is being performed, please review the notable changes for **all*
 
 ## UAN 2.4.2
 
-* There is a known issue with the version of GPU support included in the UAN CFS repo. The result is that both AMD and Nvidia SDKs are not able to be projected at the same time. Until this is resolved in a later release, modify the site.yml in the UAN CFS repo to only include either AMD or Nvidia.
+* There is a known issue with the version of GPU support included in the UAN CFS repo. The result is that both AMD and Nvidia SDKs will not project at the same time. Until this issue is resolved in a later release, modify the site.yml in the UAN CFS repo to only include either AMD or Nvidia.
 
 ## UAN 2.4.3
 
@@ -53,5 +53,5 @@ When an upgrade is being performed, please review the notable changes for **all*
 * UAN CFS configurations now require a CSM and two COS layers. Roles that were duplicated from COS CFS in the UAN CFS repo have been removed.
   * Values for COS CFS roles that were previously set in the UAN CFS group_vars directory should now be set in COS CFS group_vars
 * UAN CFS has been restructured to work for COS and Standard SLES images
-* uan_packages variables are now vars/uan_packages.yml and vars/uan_repos.yml and have been renamed. Admins will need to migrate to the new settings.
+* uan_packages variables are now `vars/uan_packages.yml` and `vars/uan_repos.yml` and have been renamed. Admins must migrate to the new settings.
 * The NMN connection now supports bonding (optional).  The default is a non-bonded single interface.


### PR DESCRIPTION
Deduped HashiCorp vault steps, style fixes, consistently say that manual image steps are pre-IUF and pre-UAN 2.6.

#### Summary and Scope

- Relates to CASMUSER-3247

##### Issue Type
<!--- Delete un-needed bullets -->


**Docs Pull Request**

- Lots of small wording changes suggested by our Acrolinx tool for spelling, grammar, readability, and other conformance to the HPE KM Style guide.
- More consistently state that the manual image creation steps (and related procedures) are only needed for pre-UAN 2.6 releases or if you are not using IUF for a 2.6+ release.
- The steps for setting the root password in the HashiCorp vault are now in one place instead of two.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this via a local build on my system. No errors from DITA-OT
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
Very low risk for breaking docs builds and performance because:

- this PR successfully builds
- no new files are added
- no files are deleted
- no new or strange Markdown syntax is added
