### PR TITLE
added JSON metadata files to those covered by variables.

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -42,7 +42,7 @@ function copy_docs {
     DATE="`date`"
     rsync -aq --exclude="hugo" "${ROOTDIR}/docs/" "${BUILDDIR}/docs/"
     # Set any dynamic variables in the UAN docs
-    for docfile in `find "${BUILDDIR}/docs/" -name "*.md" -o -name "*.ditamap" -type f`;
+    for docfile in `find "${BUILDDIR}/docs/" -name "*.md" -o -name "*.ditamap" -o -name "*publication.json" -type f`;
     do
         sed -i.bak -e "s/@product_version@/${VERSION}/g" "$docfile"
         sed -i.bak -e "s/@product_version_short@/${MAJOR}.${MINOR}/g" "$docfile"


### PR DESCRIPTION
#### Summary and Scope

This adds the HPESC-specific JSON metadata files to ones covered by the variable substitution logic. Without this fix, `@product_version@` appears in the metadata and titles of the UAN guides on HPESC.

##### Issue Type

- Docs Pull Request

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on via local builds and previewing the uploaded documents on HPESC.
 
#### Idempotency
 
N/A

#### Risks and Mitigations
 
Very low risk.
