### PR TITLE
fix image size in PDFs and workflow issues found in winter release install

### DIFF
--- a/docs/portal/developer-portal/advanced/Designating_Application_Nodes_for_K3s.md
+++ b/docs/portal/developer-portal/advanced/Designating_Application_Nodes_for_K3s.md
@@ -2,6 +2,10 @@
 
 **WARNING**: This feature is a Technical Preview. Future releases will streamline these manual configuration steps. Therefore, some of these configuration options may change in future releases.
 
+## Prerequisites
+
+- The node or nodes that will run K3s must have a local disk because Podman requires it.
+
 ## Overview
 
 Before K3s can be enabled to support UAIs on Application nodes, the Application nodes must be grouped in HSM as either `k3s_server` or `k3s_agent` nodes. The UAN Ansible K3s playbook uses these groups to determine what role they will have. Nodes grouped as `k3s_server` will become K3s control-plane (master) nodes, while nodes grouped as `k3s_agent` will become K3s agent (worker) nodes.

--- a/docs/portal/developer-portal/advanced/Enabling_K3s.md
+++ b/docs/portal/developer-portal/advanced/Enabling_K3s.md
@@ -25,6 +25,8 @@ There are alternate configurations of Podman that would allow for different work
 
 The following steps must be completed prior to configuring the UAN with K3s.
 
+1. Complete the `process-media` and `pre-install-check` IUF phases if you are performing this procedure during initial installation or upgrade.
+
 1. Designate a UAN to operate as the K3s control-plane node. See [Designating Application Nodes for K3s](Designating_Application_Nodes_for_K3s.md).
 
 1. Identify a pool of IP addresses for the services running in K3s.

--- a/docs/portal/developer-portal/build.sh
+++ b/docs/portal/developer-portal/build.sh
@@ -68,7 +68,7 @@ echo "Building UAN Install Guide";
 dita -i tmp/uan_install_guide.ditamap -o build/install -f HPEscHtml5 && cp install_publication.json build/install/publication.json && cd build/install/ && zip -r crs8032_@docid_suffix@en_us.zip ./
 cd $THIS_DIR
 # This builds the PDF using DITA-OT's default PDF transform
-dita -i uan_install_guide.ditamap -o build/PDF/install -f pdf
+dita -i uan_install_guide.ditamap --args.fo.userconfig=$THIS_DIR/fop.xconf -o build/PDF/install -f pdf
 # This builds the single file Markdown version of the guide. This leverages DITA's "chunking"
 dita -i uan_install_guide.ditamap --root-chunk-override=to-content -o build/Markdown -f markdown_github
 
@@ -77,7 +77,7 @@ echo "Building UAN Admin Guide"
 dita -i tmp/uan_admin_guide.ditamap -o build/admin -f HPEscHtml5 && cp admin_publication.json build/admin/publication.json && cd build/admin/ && zip -r crs8033_@docid_suffix@en_us.zip ./
 cd $THIS_DIR
 # This builds the PDF using DITA-OT's default PDF transform
-dita -i uan_admin_guide.ditamap -o build/PDF/admin -f pdf; 
+dita -i uan_admin_guide.ditamap --args.fo.userconfig=$THIS_DIR/fop.xconf -o build/PDF/admin -f pdf; 
 # This builds the single file Markdown version of the guide. This leverages DITA's "chunking"
 dita -i uan_admin_guide.ditamap --root-chunk-override=to-content -o build/Markdown -f markdown_github
 

--- a/docs/portal/developer-portal/fop.xconf
+++ b/docs/portal/developer-portal/fop.xconf
@@ -1,0 +1,469 @@
+<?xml version="1.0"?>
+<!-- $Id: fop.xconf 1616312 2014-08-06 19:19:31Z gadams $ -->
+
+<!--
+
+This is an example configuration file for FOP.
+This file contains the same settings as the default values
+and will have no effect if used unchanged.
+
+Relative config url's will be resolved relative to
+the location of this file.
+
+-->
+
+<!-- NOTE: This is the version of the configuration -->
+<fop version="1.0">
+
+  <!-- Strict FO validation -->
+  <strict-validation>false</strict-validation>
+
+  <!-- Base URL for resolving relative URLs -->
+  <base>.</base>
+  
+  <!-- Source resolution in dpi (dots/pixels per inch) for determining the size of pixels in SVG and bitmap images, default: 72dpi -->
+  <source-resolution>200</source-resolution>
+  <!-- Target resolution in dpi (dots/pixels per inch) for specifying the target resolution for generated bitmaps, default: 72dpi -->
+  <target-resolution>200</target-resolution>
+  
+  <!-- Default page-height and page-width, in case value is specified as auto -->
+  <default-page-settings height="11.00in" width="8.50in"/>
+  
+  <!-- Information for specific renderers -->
+  <!-- Uses renderer mime type for renderers -->
+  <renderers>
+    <renderer mime="application/pdf">
+      <filterList>
+        <!-- provides compression using zlib flate (default is on) -->
+        <value>flate</value>
+  
+        <!-- encodes binary data into printable ascii characters (default off)
+             This provides about a 4:5 expansion of data size -->
+        <!-- <value>ascii-85</value> -->
+  
+        <!-- encodes binary data with hex representation (default off)
+             This filter is not recommended as it doubles the data size -->
+        <!-- <value>ascii-hex</value> -->
+      </filterList>
+
+      <fonts>
+        <!-- embedded fonts -->
+        <!--
+        This information must exactly match the font specified
+        in the fo file. Otherwise it will use a default font.
+
+        For example,
+        <fo:inline font-family="Arial" font-weight="bold" font-style="normal">
+            Arial-normal-normal font
+        </fo:inline>
+        for the font triplet specified by:
+        <font-triplet name="Arial" style="normal" weight="bold"/>
+
+        If you do not want to embed the font in the pdf document
+        then do not include the "embed-url" attribute.
+        The font will be needed where the document is viewed
+        for it to be displayed properly.
+
+        possible styles: normal | italic | oblique | backslant
+        possible weights: normal | bold | 100 | 200 | 300 | 400
+                          | 500 | 600 | 700 | 800 | 900
+        (normal = 400, bold = 700)
+        -->
+
+        <!--
+        <font metrics-url="arial.xml" kerning="yes" embed-url="arial.ttf">
+          <font-triplet name="Arial" style="normal" weight="normal"/>
+          <font-triplet name="ArialMT" style="normal" weight="normal"/>
+        </font>
+        <font metrics-url="arialb.xml" kerning="yes" embed-url="arialb.ttf">
+          <font-triplet name="Arial" style="normal" weight="bold"/>
+          <font-triplet name="ArialMT" style="normal" weight="bold"/>
+        </font>
+        -->
+
+        <!-- auto-detect fonts -->
+        <auto-detect/>
+
+      </fonts>
+
+      <!-- This option lets you specify additional options on an XML handler -->
+      <!--xml-handler namespace="http://www.w3.org/2000/svg">
+        <stroke-text>false</stroke-text>
+      </xml-handler-->
+
+    </renderer>
+
+    <renderer mime="application/x-afp">
+      <!--
+           The bit depth and type of images produced
+           (this is the default setting)
+      -->
+      <images mode="b+w" bits-per-pixel="8"/>
+      <renderer-resolution>240</renderer-resolution>
+      <line-width-correction>2.5</line-width-correction>
+      <resource-group-file>resources.afp</resource-group-file>
+
+      <fonts>
+      <!--
+           Below is an example using raster font configuration using FOP builtin base-14 font metrics.
+           for Times Roman, Helvetica and Courier.
+
+           Depending on AFP raster and outline font availability on your installation you will
+           most likely need to modify the configuration provided below.
+
+           See http://xmlgraphics.apache.org/fop/trunk/output.html#afp-configuration
+           for details of FOP configuration for AFP
+      -->
+
+        <!-- Times Roman -->
+        <font>
+          <afp-font name="Times Roman" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0N20060" base14-font="TimesRoman"/>
+            <afp-raster-font size="7" characterset="C0N20070" base14-font="TimesRoman"/>
+            <afp-raster-font size="8" characterset="C0N20080" base14-font="TimesRoman"/>
+            <afp-raster-font size="9" characterset="C0N20090" base14-font="TimesRoman"/>
+            <afp-raster-font size="10" characterset="C0N20000" base14-font="TimesRoman"/>
+            <afp-raster-font size="11" characterset="C0N200A0" base14-font="TimesRoman"/>
+            <afp-raster-font size="12" characterset="C0N200B0" base14-font="TimesRoman"/>
+            <afp-raster-font size="14" characterset="C0N200D0" base14-font="TimesRoman"/>
+            <afp-raster-font size="16" characterset="C0N200F0" base14-font="TimesRoman"/>
+            <afp-raster-font size="18" characterset="C0N200H0" base14-font="TimesRoman"/>
+            <afp-raster-font size="20" characterset="C0N200J0" base14-font="TimesRoman"/>
+            <afp-raster-font size="24" characterset="C0N200N0" base14-font="TimesRoman"/>
+            <afp-raster-font size="30" characterset="C0N200T0" base14-font="TimesRoman"/>
+            <afp-raster-font size="36" characterset="C0N200Z0" base14-font="TimesRoman"/>
+          </afp-font>
+          <font-triplet name="Times" style="normal" weight="normal"/>
+          <font-triplet name="TimesRoman" style="normal" weight="normal"/>
+          <font-triplet name="Times Roman" style="normal" weight="normal"/>
+          <font-triplet name="Times-Roman" style="normal" weight="normal"/>
+          <font-triplet name="Times New Roman" style="normal" weight="normal"/>
+          <font-triplet name="TimesNewRoman" style="normal" weight="normal"/>
+          <font-triplet name="serif" style="normal" weight="normal"/>
+        </font>
+ 
+        <!-- Times Roman Italic -->
+        <font>
+          <afp-font name="Times Roman Italic" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0N30060" base14-font="TimesItalic"/>
+            <afp-raster-font size="7" characterset="C0N30070" base14-font="TimesItalic"/>
+            <afp-raster-font size="8" characterset="C0N30080" base14-font="TimesItalic"/>
+            <afp-raster-font size="9" characterset="C0N30090" base14-font="TimesItalic"/>
+            <afp-raster-font size="10" characterset="C0N30000" base14-font="TimesItalic"/>
+            <afp-raster-font size="11" characterset="C0N300A0" base14-font="TimesItalic"/>
+            <afp-raster-font size="12" characterset="C0N300B0" base14-font="TimesItalic"/>
+            <afp-raster-font size="14" characterset="C0N300D0" base14-font="TimesItalic"/>
+            <afp-raster-font size="16" characterset="C0N300F0" base14-font="TimesItalic"/>
+            <afp-raster-font size="18" characterset="C0N300H0" base14-font="TimesItalic"/>
+            <afp-raster-font size="20" characterset="C0N300J0" base14-font="TimesItalic"/>
+            <afp-raster-font size="24" characterset="C0N300N0" base14-font="TimesItalic"/>
+            <afp-raster-font size="30" characterset="C0N300T0" base14-font="TimesItalic"/>
+            <afp-raster-font size="36" characterset="C0N300Z0" base14-font="TimesItalic"/>
+          </afp-font>
+          <font-triplet name="Times" style="italic" weight="normal"/>
+          <font-triplet name="TimesRoman" style="italic" weight="normal"/>
+          <font-triplet name="Times Roman" style="italic" weight="normal"/>
+          <font-triplet name="Times-Roman" style="italic" weight="normal"/>
+          <font-triplet name="Times New Roman" style="italic" weight="normal"/>
+          <font-triplet name="TimesNewRoman" style="italic" weight="normal"/>
+          <font-triplet name="serif" style="italic" weight="normal"/>
+        </font>
+ 
+        <!-- Times Roman Bold -->
+        <font>
+          <afp-font name="Times Roman Bold" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0N40060" base14-font="TimesBold"/>
+            <afp-raster-font size="7" characterset="C0N40070" base14-font="TimesBold"/>
+            <afp-raster-font size="8" characterset="C0N40080" base14-font="TimesBold"/>
+            <afp-raster-font size="9" characterset="C0N40090" base14-font="TimesBold"/>
+            <afp-raster-font size="10" characterset="C0N40000" base14-font="TimesBold"/>
+            <afp-raster-font size="11" characterset="C0N400A0" base14-font="TimesBold"/>
+            <afp-raster-font size="12" characterset="C0N400B0" base14-font="TimesBold"/>
+            <afp-raster-font size="14" characterset="C0N400D0" base14-font="TimesBold"/>
+            <afp-raster-font size="16" characterset="C0N400F0" base14-font="TimesBold"/>
+            <afp-raster-font size="18" characterset="C0N400H0" base14-font="TimesBold"/>
+            <afp-raster-font size="20" characterset="C0N400J0" base14-font="TimesBold"/>
+            <afp-raster-font size="24" characterset="C0N400N0" base14-font="TimesBold"/>
+            <afp-raster-font size="30" characterset="C0N400T0" base14-font="TimesBold"/>
+            <afp-raster-font size="36" characterset="C0N400Z0" base14-font="TimesBold"/>
+          </afp-font>
+          <font-triplet name="Times" style="normal" weight="bold"/>
+          <font-triplet name="TimesRoman" style="normal" weight="bold"/>
+          <font-triplet name="Times Roman" style="normal" weight="bold"/>
+          <font-triplet name="Times-Roman" style="normal" weight="bold"/>
+          <font-triplet name="Times New Roman" style="normal" weight="bold"/>
+          <font-triplet name="TimesNewRoman" style="normal" weight="bold"/>
+          <font-triplet name="serif" style="normal" weight="bold"/>
+        </font>
+
+        <!-- Times Roman Italic Bold -->
+        <font>
+          <afp-font name="Times Roman Italic Bold" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0N50060" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="7" characterset="C0N50070" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="8" characterset="C0N50080" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="9" characterset="C0N50090" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="10" characterset="C0N50000" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="11" characterset="C0N500A0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="12" characterset="C0N500B0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="14" characterset="C0N500D0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="16" characterset="C0N500F0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="18" characterset="C0N500H0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="20" characterset="C0N500J0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="24" characterset="C0N500N0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="30" characterset="C0N500T0" base14-font="TimesBoldItalic"/>
+            <afp-raster-font size="36" characterset="C0N500Z0" base14-font="TimesBoldItalic"/>
+          </afp-font>
+          <font-triplet name="Times" style="italic" weight="bold"/>
+          <font-triplet name="TimesRoman" style="italic" weight="bold"/>
+          <font-triplet name="Times Roman" style="italic" weight="bold"/>
+          <font-triplet name="Times-Roman" style="italic" weight="bold"/>
+          <font-triplet name="Times New Roman" style="italic" weight="bold"/>
+          <font-triplet name="TimesNewRoman" style="italic" weight="bold"/>
+          <font-triplet name="serif" style="italic" weight="bold"/>
+        </font>
+
+        <!-- Helvetica -->
+        <font>
+          <afp-font name="Helvetica" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0H20060" base14-font="Helvetica"/>
+            <afp-raster-font size="7" characterset="C0H20070" base14-font="Helvetica"/>
+            <afp-raster-font size="8" characterset="C0H20080" base14-font="Helvetica"/>
+            <afp-raster-font size="9" characterset="C0H20090" base14-font="Helvetica"/>
+            <afp-raster-font size="10" characterset="C0H20000" base14-font="Helvetica"/>
+            <afp-raster-font size="11" characterset="C0H200A0" base14-font="Helvetica"/>
+            <afp-raster-font size="12" characterset="C0H200B0" base14-font="Helvetica"/>
+            <afp-raster-font size="14" characterset="C0H200D0" base14-font="Helvetica"/>
+            <afp-raster-font size="16" characterset="C0H200F0" base14-font="Helvetica"/>
+            <afp-raster-font size="18" characterset="C0H200H0" base14-font="Helvetica"/>
+            <afp-raster-font size="20" characterset="C0H200J0" base14-font="Helvetica"/>
+            <afp-raster-font size="24" characterset="C0H200N0" base14-font="Helvetica"/>
+            <afp-raster-font size="30" characterset="C0H200T0" base14-font="Helvetica"/>
+            <afp-raster-font size="36" characterset="C0H200Z0" base14-font="Helvetica"/>
+          </afp-font>
+          <font-triplet name="Helvetica" style="normal" weight="normal"/>
+          <font-triplet name="Arial" style="normal" weight="normal"/>
+          <font-triplet name="sans-serif" style="normal" weight="normal"/>
+          <font-triplet name="any" style="normal" weight="normal"/>
+        </font>
+
+        <!-- Helvetica Italic -->
+        <font>
+          <afp-font name="Helvetica Italic" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0H30060" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="7" characterset="C0H30070" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="8" characterset="C0H30080" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="9" characterset="C0H30090" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="10" characterset="C0H30000" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="11" characterset="C0H300A0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="12" characterset="C0H300B0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="14" characterset="C0H300D0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="16" characterset="C0H300F0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="18" characterset="C0H300H0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="20" characterset="C0H300J0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="24" characterset="C0H300N0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="30" characterset="C0H300T0" base14-font="HelveticaOblique"/>
+            <afp-raster-font size="36" characterset="C0H300Z0" base14-font="HelveticaOblique"/>
+          </afp-font>
+          <font-triplet name="Helvetica" style="italic" weight="normal"/>
+          <font-triplet name="Arial" style="italic" weight="normal"/>
+          <font-triplet name="sans-serif" style="italic" weight="normal"/>
+        </font>
+
+        <!-- Helvetica (Semi) Bold -->
+        <font>
+          <afp-font name="Helvetica (Semi) Bold" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0H40060" base14-font="HelveticaBold"/>
+            <afp-raster-font size="7" characterset="C0H40070" base14-font="HelveticaBold"/>
+            <afp-raster-font size="8" characterset="C0H40080" base14-font="HelveticaBold"/>
+            <afp-raster-font size="9" characterset="C0H40090" base14-font="HelveticaBold"/>
+            <afp-raster-font size="10" characterset="C0H40000" base14-font="HelveticaBold"/>
+            <afp-raster-font size="11" characterset="C0H400A0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="12" characterset="C0H400B0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="14" characterset="C0H400D0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="16" characterset="C0H400F0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="18" characterset="C0H400H0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="20" characterset="C0H400J0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="24" characterset="C0H400N0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="30" characterset="C0H400T0" base14-font="HelveticaBold"/>
+            <afp-raster-font size="36" characterset="C0H400Z0" base14-font="HelveticaBold"/>
+          </afp-font>
+          <font-triplet name="Helvetica" style="normal" weight="bold"/>
+          <font-triplet name="Arial" style="normal" weight="bold"/>
+          <font-triplet name="sans-serif" style="normal" weight="bold"/>
+        </font>
+
+        <!-- Helvetica Italic (Semi) Bold -->
+        <font>
+          <afp-font name="Helvetica Italic (Semi) Bold" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0H50060" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="7" characterset="C0H50070" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="8" characterset="C0H50080" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="9" characterset="C0H50090" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="10" characterset="C0H50000" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="11" characterset="C0H500A0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="12" characterset="C0H500B0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="14" characterset="C0H500D0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="16" characterset="C0H500F0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="18" characterset="C0H500H0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="20" characterset="C0H500J0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="24" characterset="C0H500N0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="30" characterset="C0H500T0" base14-font="HelveticaBoldOblique"/>
+            <afp-raster-font size="36" characterset="C0H500Z0" base14-font="HelveticaBoldOblique"/>
+          </afp-font>
+          <font-triplet name="Helvetica" style="italic" weight="bold"/>
+          <font-triplet name="Arial" style="italic" weight="bold"/>
+          <font-triplet name="sans-serif" style="italic" weight="bold"/>
+        </font>
+
+        <!-- Courier -->
+        <font>
+          <afp-font name="Courier" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0420060" base14-font="Courier"/>
+            <afp-raster-font size="7" characterset="C0420070" base14-font="Courier"/>
+            <afp-raster-font size="8" characterset="C0420080" base14-font="Courier"/>
+            <afp-raster-font size="9" characterset="C0420090" base14-font="Courier"/>
+            <afp-raster-font size="10" characterset="C0420000" base14-font="Courier"/>
+            <afp-raster-font size="11" characterset="C04200A0" base14-font="Courier"/>
+            <afp-raster-font size="12" characterset="C04200B0" base14-font="Courier"/>
+            <afp-raster-font size="14" characterset="C04200D0" base14-font="Courier"/>
+            <afp-raster-font size="16" characterset="C04200F0" base14-font="Courier"/>
+            <afp-raster-font size="18" characterset="C04200H0" base14-font="Courier"/>
+            <afp-raster-font size="20" characterset="C04200J0" base14-font="Courier"/>
+            <afp-raster-font size="24" characterset="C04200N0" base14-font="Courier"/>
+            <afp-raster-font size="30" characterset="C04200T0" base14-font="Courier"/>
+            <afp-raster-font size="36" characterset="C04200Z0" base14-font="Courier"/>
+          </afp-font>
+          <font-triplet name="Courier" style="normal" weight="normal"/>
+          <font-triplet name="monospace" style="normal" weight="normal"/>
+        </font>
+
+        <!-- Courier Italic -->
+        <font>
+          <afp-font name="Courier Italic" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0430060" base14-font="CourierOblique"/>
+            <afp-raster-font size="7" characterset="C0430070" base14-font="CourierOblique"/>
+            <afp-raster-font size="8" characterset="C0430080" base14-font="CourierOblique"/>
+            <afp-raster-font size="9" characterset="C0430090" base14-font="CourierOblique"/>
+            <afp-raster-font size="10" characterset="C0430000" base14-font="CourierOblique"/>
+            <afp-raster-font size="11" characterset="C04300A0" base14-font="CourierOblique"/>
+            <afp-raster-font size="12" characterset="C04300B0" base14-font="CourierOblique"/>
+            <afp-raster-font size="14" characterset="C04300D0" base14-font="CourierOblique"/>
+            <afp-raster-font size="16" characterset="C04300F0" base14-font="CourierOblique"/>
+            <afp-raster-font size="18" characterset="C04300H0" base14-font="CourierOblique"/>
+            <afp-raster-font size="20" characterset="C04300J0" base14-font="CourierOblique"/>
+            <afp-raster-font size="24" characterset="C04300N0" base14-font="CourierOblique"/>
+            <afp-raster-font size="30" characterset="C04300T0" base14-font="CourierOblique"/>
+            <afp-raster-font size="36" characterset="C04300Z0" base14-font="CourierOblique"/>
+          </afp-font>
+          <font-triplet name="Courier" style="italic" weight="normal"/>
+          <font-triplet name="monospace" style="italic" weight="normal"/>
+        </font>
+
+        <!-- Courier Bold -->
+        <font>
+          <afp-font name="Courier Bold" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0440060" base14-font="CourierBold"/>
+            <afp-raster-font size="7" characterset="C0440070" base14-font="CourierBold"/>
+            <afp-raster-font size="8" characterset="C0440080" base14-font="CourierBold"/>
+            <afp-raster-font size="9" characterset="C0440090" base14-font="CourierBold"/>
+            <afp-raster-font size="10" characterset="C0440000" base14-font="CourierBold"/>
+            <afp-raster-font size="11" characterset="C04400A0" base14-font="CourierBold"/>
+            <afp-raster-font size="12" characterset="C04400B0" base14-font="CourierBold"/>
+            <afp-raster-font size="14" characterset="C04400D0" base14-font="CourierBold"/>
+            <afp-raster-font size="16" characterset="C04400F0" base14-font="CourierBold"/>
+            <afp-raster-font size="18" characterset="C04400H0" base14-font="CourierBold"/>
+            <afp-raster-font size="20" characterset="C04400J0" base14-font="CourierBold"/>
+            <afp-raster-font size="24" characterset="C04400N0" base14-font="CourierBold"/>
+            <afp-raster-font size="30" characterset="C04400T0" base14-font="CourierBold"/>
+            <afp-raster-font size="36" characterset="C04400Z0" base14-font="CourierBold"/>
+          </afp-font>
+          <font-triplet name="Courier" style="normal" weight="bold"/>
+          <font-triplet name="monospace" style="normal" weight="bold"/>
+        </font>
+
+        <!-- Courier Italic Bold -->
+        <font>
+          <afp-font name="Courier Italic Bold" type="raster" codepage="T1V10500" encoding="Cp500">
+            <afp-raster-font size="6" characterset="C0450060" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="7" characterset="C0450070" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="8" characterset="C0450080" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="9" characterset="C0450090" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="10" characterset="C0450000" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="11" characterset="C04500A0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="12" characterset="C04500B0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="14" characterset="C04500D0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="16" characterset="C04500F0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="18" characterset="C04500H0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="20" characterset="C04500J0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="24" characterset="C04500N0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="30" characterset="C04500T0" base14-font="CourierBoldOblique"/>
+            <afp-raster-font size="36" characterset="C04500Z0" base14-font="CourierBoldOblique"/>
+          </afp-font>
+          <font-triplet name="Courier" style="italic" weight="bold"/>
+          <font-triplet name="monospace" style="italic" weight="bold"/>
+        </font>
+        
+         <!-- 
+        Configure double-byte (CID Keyed font (Type 0)) AFP fonts with type="CIDKeyed".  
+        
+        example:
+         <font>
+                <afp-font type="CIDKeyed" encoding="UnicodeBigUnmarked"  
+                codepage="T1120000" characterset="CZJHMNU" 
+                base-uri="fonts" />
+                <font-triplet name="J-Heisei Mincho" style="normal" weight="normal" />
+         </font>
+        -->
+        
+        
+      </fonts>
+    </renderer>
+
+    <renderer mime="application/postscript">
+      <!-- This option forces the PS renderer to rotate landscape pages -->
+      <!--auto-rotate-landscape>true</auto-rotate-landscape-->
+      
+      <!-- This option lets you specify additional options on an XML handler -->
+      <!--xml-handler namespace="http://www.w3.org/2000/svg">
+        <stroke-text>false</stroke-text>
+      </xml-handler-->
+    </renderer>
+
+    <renderer mime="application/vnd.hp-PCL">
+    </renderer>
+
+    <!-- MIF does not have a renderer
+    <renderer mime="application/vnd.mif">
+    </renderer>
+    -->
+
+    <renderer mime="image/svg+xml">
+      <format type="paginated"/>
+      <link value="true"/>
+      <strokeText value="false"/>
+    </renderer>
+
+    <renderer mime="application/awt">
+    </renderer>
+
+    <renderer mime="image/png">
+      <!--transparent-page-background>true</transparent-page-background-->
+    </renderer>
+
+    <renderer mime="image/tiff">
+      <!--transparent-page-background>true</transparent-page-background-->
+      <!--compression>CCITT T.6</compression-->
+    </renderer>
+
+    <renderer mime="text/xml">
+    </renderer>
+
+    <!-- RTF does not have a renderer
+    <renderer mime="text/rtf">
+    </renderer>
+    -->
+
+  </renderers>
+
+</fop>

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -61,6 +61,8 @@ This section describes any UAN details that an administrator must be aware of be
 
 **Action**: Before executing this stage, any site-local UAN configuration changes must be made so that the following stages execute using the wanted UAN configuration values. See the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section of this documentation for UAN configuration content details. The [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh installation scenarios.
 
+The procedures in this guide assume that the HPE Cray Supercomputing EX system has dedicated UANs. If the HPE Cray Supercomputing EX system does not have dedicated UANs, skip the steps for installing and  configuring them. 
+
 ## UAN Content Installed
 
 The following subsections describe most of the UAN content installed and configured on the system by IUF. The new version of UAN \(2.6.XX\) and its artifacts will be displayed in the CSM product catalog alongside any previously released version of UAN and its artifacts.

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -61,7 +61,7 @@ This section describes any UAN details that an administrator must be aware of be
 
 **Action**: Before executing this stage, any site-local UAN configuration changes must be made so that the following stages execute using the wanted UAN configuration values. See the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section of this documentation for UAN configuration content details. The [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh installation scenarios.
 
-The procedures in this guide assume that the HPE Cray Supercomputing EX system has dedicated UANs. If the HPE Cray Supercomputing EX system does not have dedicated UANs, skip the steps for installing and  configuring them. 
+The procedures in this guide assume that the HPE Cray Supercomputing EX system has dedicated UANs. If the HPE Cray Supercomputing EX system does not have dedicated UANs, skip the steps for installing and configuring them. 
 
 ## UAN Content Installed
 

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -65,12 +65,12 @@ The procedures in this guide assume that the HPE Cray Supercomputing EX system h
 
 ## UAN Content Installed
 
-The following subsections describe most of the UAN content installed and configured on the system by IUF. The new version of UAN \(2.6.XX\) and its artifacts will be displayed in the CSM product catalog alongside any previously released version of UAN and its artifacts.
+The following subsections describe most of the UAN content installed and configured on the system by IUF. The new version of UAN \(2.7.XX\) and its artifacts will be displayed in the CSM product catalog alongside any previously released version of UAN and its artifacts.
 
 
 ### Configuration
 
-UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number. That release number, such as \(2.6.XX\) distinguishes it from any previously released UAN configuration content. This content is described in detail in the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section.
+UAN provides configuration content in the form of Ansible roles and plays. This content is uploaded to a VCS repository in a branch with a specific UAN version number. That release number, such as \(2.7.XX\) distinguishes it from any previously released UAN configuration content. This content is described in detail in the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section.
 
 For application nodes based on COS, the COS compute image is used as the base application node image and two COS CFS layers are required. The first COS CFS layer runs the `cos-application.yml` Ansible playbook and ensures that the COS content is applied as part of the image customization and node personalization processes. This COS CFS layer must precede the UAN CFS layer in the UAN CFS configuration. A second COS CFS layer running the Ansible playbook, `cos-application-after.yml`, runs after the UAN CFS layer of the UAN CFS configuration. This second COS CFS layer ensures that the application node initrd is rebuilt and that any customer-defined filesystems are configured.
 
@@ -149,12 +149,12 @@ UAN provides RPMs used on UAN nodes. The RPMs are uploaded to Nexus as part of t
 
 The following Nexus raw repositories are created:
 
-- uan-2.6.XX-sle-15sp4
-- uan-2.6.XX-sle-15sp3
+- uan-2.7.XX-sle-15sp4
+- uan-2.7.XX-sle-15sp3
 
 The following Nexus group repositories are created and reference the preceding Nexus raw repos.
 
-- uan-2.6-sle-15sp4
-- uan-2.6-sle-15sp3
+- uan-2.7-sle-15sp4
+- uan-2.7-sle-15sp3
 
-The uan-2.6-sle-15sp4 and uan-2.6-sle-15sp3 Nexus group repositories are used when building UAN node images and are accessible on UAN nodes after boot.
+The uan-2.7-sle-15sp4 and uan-2.7-sle-15sp3 Nexus group repositories are used when building UAN node images and are accessible on UAN nodes after boot.

--- a/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
+++ b/docs/portal/developer-portal/install/Install_the_UAN_Product_Stream.md
@@ -61,7 +61,7 @@ This section describes any UAN details that an administrator must be aware of be
 
 **Action**: Before executing this stage, any site-local UAN configuration changes must be made so that the following stages execute using the wanted UAN configuration values. See the [Basic UAN Configuration](../operations/Basic_UAN_Configuration.md) section of this documentation for UAN configuration content details. The [Prepare for UAN Product Installation](../installation_prereqs/Prepare_for_UAN_Product_Installation.md) section is required for fresh installation scenarios.
 
-The procedures in this guide assume that the HPE Cray Supercomputing EX system has dedicated UANs. If the HPE Cray Supercomputing EX system does not have dedicated UANs, skip the steps for installing and configuring them. 
+The procedures in this guide assume that the HPE Cray Supercomputing EX system has dedicated UANs. If the HPE Cray Supercomputing EX system does not have dedicated UANs, skip the steps for installing and configuring them.
 
 ## UAN Content Installed
 
@@ -143,18 +143,14 @@ The UAN product provides an Application Node image. This image is based on SUSE 
 
 Customers must finish the installation or upgrade of the UAN product before booting an Application Node with SLE HPC 15 provided by that UAN product release. See [Booting an Application Node with a SLES Image (Technical Preview)](../advanced/SLES_Image.md) for more information about this image and instructions on deploying it to Application Nodes.
 
-### RPMs
+### Third-Party Packages
 
-UAN provides RPMs used on UAN nodes. The RPMs are uploaded to Nexus as part of the installation process.
+UAN provides some third-party packages used on UAN nodes. The third-party packages are uploaded to Nexus as part of the installation process.
 
 The following Nexus raw repositories are created:
 
-- uan-2.7.XX-sle-15sp4
-- uan-2.7.XX-sle-15sp3
+- uan-@product_version@-third-party
 
 The following Nexus group repositories are created and reference the preceding Nexus raw repos.
 
-- uan-2.7-sle-15sp4
-- uan-2.7-sle-15sp3
-
-The uan-2.7-sle-15sp4 and uan-2.7-sle-15sp3 Nexus group repositories are used when building UAN node images and are accessible on UAN nodes after boot.
+- uan-@product_version_short@-third-party

--- a/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
+++ b/docs/portal/developer-portal/installation_prereqs/Prepare_for_UAN_Product_Installation.md
@@ -4,6 +4,8 @@ Perform this procedure to ready the HPE Cray Supercomputing EX system for HPE Cr
 
 Install and configure the HPE Cray Supercomputing COS product before performing this procedure.
 
+If the HPE Cray Supercomputing EX system contains Compute Nodes (CNs) that will be repurposed as UANs, those CNs must be configured as CNs first. The _HPE Cray Supercomputing User Access Node (UAN) Administrator Guide (S-8033)_ provides instructions for reconfiguring a CN as UAN after product installation.
+
 1. Verify that the management network switches are properly configured.
 
    See the [switch configuration procedures](https://cray-hpe.github.io/docs-csm/en-14/install/csm-install/readme/#5-configure-management-network-switches) in the HPE Cray System Management Documentation.
@@ -16,9 +18,9 @@ Install and configure the HPE Cray Supercomputing COS product before performing 
 
     See the procedure "Add UAN CAN IP Addresses to SLS" in the HPE Cray Supercomputing EX hardware documentation.
 
-    1. For systems where UANs are going to host UAIs, identify a block of IP addresses for the services running in K3s. Please see [Configuring a UAN for K3s (Technical Preview)](../advanced/Enabling_K3s.md) for information on reserving a block of IPs on CAN/CHN for K3s MetalLB use.
+    1. For systems where UANs are going to host UAIs, identify a block of IP addresses for the services running in K3s. Please see [Configuring a UAN for K3s (Technical Preview)](../advanced/Enabling_K3s.md) for information on reserving a block of IP addresses on CAN/CHN for K3s MetalLB use.
 
-       **Note**: The identification of IP addresses for the services running in K3s should be made at system installation time in order to avoid the possibility of IP collisions with CSM services.
+       **Note**: The identification of IP addresses for the services running in K3s should be made at system installation time to avoid the possibility of IP collisions with CSM services.
    
 1. [Configure the BMC for UANs with iLO](Configure_the_BMC_for_UANs_with_iLO.md)
 

--- a/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
+++ b/docs/portal/developer-portal/operations/Basic_UAN_Configuration.md
@@ -77,7 +77,7 @@ The name of the playbook must match the name of the HSN NICs (Mellanox or Cassin
 
 ### COS (playbook: cos-application.yml)
 
-The second CFS Layer runs the following roles from the `cos-config-management` VCS repository. Any configuration changes needed for these roles must be made in the `cos-config-management` `group_vars` or `host_vars` subdirectories of that repository.
+The second CFS Layer runs the following roles from the `uss-config-management` VCS repository. Any configuration changes needed for these roles must be made in the `uss-config-management` `group_vars` or `host_vars` subdirectories of that repository.
 
 The following Ansible roles are run during UAN image configuration:
 
@@ -151,7 +151,7 @@ The UAN roles in `site.yml` are required and must not be removed, with exception
 
 ### COS (playbook: cos-application-after.yml)
 
-This CFS Layer runs the following roles from the `cos-config-management` VCS repository. Any configuration changes needed for these roles must be made in the `group_vars` or `host_vars` subdirectories of that repository.
+This CFS Layer runs the following roles from the `uss-config-management` VCS repository. Any configuration changes needed for these roles must be made in the `group_vars` or `host_vars` subdirectories of that repository.
 
 The following Ansible roles are run during UAN image configuration:
 

--- a/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
+++ b/docs/portal/developer-portal/operations/Build_a_New_UAN_Image_Using_the_COS_Recipe.md
@@ -31,7 +31,7 @@ Before using IUF to build a new UAN image from a COS recipe, be sure that the in
     working_branch: "{{ working_branch }}" # COS CFS branch to use (typically matches compute nodes)
 
   uan:
-    version: 2.6.0 # Provides the UAN CFS configuration
+    version: 2.7.0 # Provides the UAN CFS configuration
     working_branch: "{{ working_branch }}" # Provides the UAN CFS branch to use
   ```
 

--- a/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
+++ b/docs/portal/developer-portal/operations/Create_UAN_Boot_Images.md
@@ -198,13 +198,13 @@ See also [*HPE Cray EX System Software Stack Installation and Upgrade Guide for 
        playbook: set_nologin.yml
        product:
          name: uan
-         version: 2.6.0
+         version: 2.7.0
          branch: integration-PRODUCT_VERSION
      - name: uan
        playbook: site.yml
        product:
          name: uan
-         version: 2.6.0
+         version: 2.7.0
          branch: integration-PRODUCT_VERSION
   
      ... add configuration layers for other products here, if desired ...
@@ -213,13 +213,13 @@ See also [*HPE Cray EX System Software Stack Installation and Upgrade Guide for 
        playbook: rebuild-initrd.yml
        product:
          name: uan
-         version: 2.6.0
+         version: 2.7.0
          branch: integration-PRODUCT_VERSION
      - name: uan-unset-nologin
        playbook: unset_nologin.yml
        product:
          name: uan
-         version: 2.6.0
+         version: 2.7.0
          branch: integration-PRODUCT_VERSION
    ```
 

--- a/docs/portal/developer-portal/uan_install_guide.ditamap
+++ b/docs/portal/developer-portal/uan_install_guide.ditamap
@@ -19,6 +19,10 @@
         <topicref href="operations/Configure_Interfaces_on_UANs.md" format="markdown"/>
         <topicref href="advanced/Enabling_CAN_CHN.md" format="markdown"/>
     </topicref>
+    <topichead navtitle="Advanced UAN Configuration">
+        <topicref href="advanced/Designating_Application_Nodes_for_K3s.md" format="markdown"/>
+        <topicref href="advanced/Enabling_K3s.md" format="markdown"/>
+    </topichead>
     <topichead>
         <topicmeta>
             <navtitle>UAN Ansible Roles</navtitle>

--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -18,8 +18,8 @@ When an upgrade is being performed, review the notable changes for **all** the U
 
 ## UAN 2.4.0
 
-* UAN 2.4.0 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.  
-  * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customer user network.  By default, a direct connection is selected as it was in previous releases.  
+* UAN 2.4.0 adds support for a Bifurcated Customer Access Network \(BiCAN\) and the ability to specify a default route other than the CAN or CHN when they are selected.
+  * Application nodes may now choose to implement user access over either the existing Customer Access Network \(CAN\), the new Customer High Speed Network \(CHN\), or a direct connection to the customer user network.  By default, a direct connection is selected as it was in previous releases.
     * `uan_can_setup`, when set to `yes`, selects the customer access network implementation based on the setting of the BICAN System Default Route in SLS.
     * Application nodes may now set a default route other than the CAN or CHN default route when `uan_can_setup: yes`.
     * `uan_customer_default_route: true` will allow a customer-defined default route to be set using the `customer_uan_routes` structure when `uan_can_setup` is set to `yes`.
@@ -55,3 +55,9 @@ When an upgrade is being performed, review the notable changes for **all** the U
 * UAN CFS has been restructured to work for COS and Standard SLES images
 * uan_packages variables are now `vars/uan_packages.yml` and `vars/uan_repos.yml` and have been renamed. Admins must migrate to the new settings.
 * The NMN connection now supports bonding (optional).  The default is a non-bonded single interface.
+
+## UAN 2.7.1
+
+* K3s may be optionally deployed to UANs using the playbook k3s.yaml
+* A new Nexus raw repo provides 3rd party packages to deploy k3s and related services
+* UAN rpms have been removed and replaced with ansible roles


### PR DESCRIPTION
See description of TECHPUBS-4040 for details of fixes and rationale. **This is the fix for the main branch. I'll create another PR for the 2.7 release branch after this one merges**

The new `fop.xconf` is only used by Apache FOP as part of the PDF build process. The file in our docs repo overrides the file of the same name used by the default DITA-OT PDF transform.

The two K3s procedures now appear in both the Install and Admin Guides. I'm open to removing it from the Admin Guide if we decide setting up K3s should only be done during install or upgrade.

#### Summary and Scope

- Fixes TECHPUBS-4040


##### Issue Type

- Docs Pull Request

Fixes image sizing in PDF output and corrects some workflow issues.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system: tested by locally building PDFs of the Install and Admin Guides.
 
#### Idempotency
 
N/A
 
#### Risks and Mitigations
 
For the PDF image sizing: the only new risk is if we decide to add more graphics and/or screenshots to the docs and 200 dpi either results in the image being to large and thus cut off (unlikely), or makes the image too small to be usable (also unlikely, and plus the reader can zoom in in their PDF viewer).

For the K3s workflow changes: there is a risk that I broke some procedure dependency chain.
