### PR TITLE
Update release list for 2.7.3

### DIFF
--- a/docs/portal/developer-portal/upgrade/Notable_Changes.md
+++ b/docs/portal/developer-portal/upgrade/Notable_Changes.md
@@ -61,3 +61,7 @@ When an upgrade is being performed, review the notable changes for **all** the U
 * K3s may be optionally deployed to UANs using the playbook k3s.yaml
 * A new Nexus raw repo provides 3rd party packages to deploy k3s and related services
 * UAN rpms have been removed and replaced with ansible roles
+
+## UAN 2.7.3
+
+* Update to the `Install or Upgrade UAN` documentation to reference the prerequisites needed when UAIs on UANs are to be enabled.

--- a/release_list.yml
+++ b/release_list.yml
@@ -2,8 +2,6 @@
 # List releases in the order they should appear in the documentation
 # version menu.  Default at the top of the list.
 releases:
-  - 2.7.1
-  - 2.7.0
+  - 2.7.3
   - 2.6.2
-  - 2.6.1
   - 2.5.11


### PR DESCRIPTION
#### Summary and Scope

This PR updates the doc versions to be built. UAN 2.7.3 is the latest version.

This PR must be merged after https://github.com/Cray-HPE/docs-uan/pull/62 is merged.  That PR will enable the creation of the tag 2.7.3 referenced in this PR.